### PR TITLE
Add coverage enforcement to pytest comparison workflow

### DIFF
--- a/.github/workflows/test-py-pytest.yml
+++ b/.github/workflows/test-py-pytest.yml
@@ -75,6 +75,7 @@ jobs:
       failing_count: ${{ steps.extract-results.outputs.failing_count }}
       skipped_count: ${{ steps.extract-results.outputs.skipped_count }}
       xfailed_count: ${{ steps.extract-results.outputs.xfailed_count }}
+      coverage: ${{ steps.extract-results.outputs.coverage }}
 
     steps:
       - name: Checkout PR Branch
@@ -90,7 +91,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-json-report pytest-asyncio
+          pip install pytest pytest-json-report pytest-asyncio pytest-cov
           if [ -f requirements.txt ]; then 
             pip install -r requirements.txt
           fi
@@ -182,7 +183,7 @@ jobs:
         if: steps.check-collection.outputs.has_collection_errors != 'true'
         run: |
           echo "Running tests on PR branch..."
-          python -m pytest -vv --json-report --json-report-file=pr_results.json --tb=short > test_output.txt 2>&1 || true
+          python -m pytest -vv --json-report --json-report-file=pr_results.json --tb=short --cov=. --cov-report=term --cov-report=json:pr_coverage.json > test_output.txt 2>&1 || true
 
           if [ -f pr_results.json ]; then
             echo "✅ Test execution completed"
@@ -208,6 +209,7 @@ jobs:
           skipped_tests = []
           xfailed_tests = []
           all_tests = []
+          coverage_percent = 0.0
           passing_tests = []
           skipped_tests_with_reasons = {}
           xfailed_tests_with_reasons = {}
@@ -283,6 +285,18 @@ jobs:
               # Calculate percentage safely
               pr_percentage = (pr_passed / pr_total * 100) if pr_total > 0 else 0
               print(f'Pass percentage calculated: {pr_percentage:.2f}%')
+
+          try:
+              with open('pr_coverage.json') as f:
+                  coverage_data = json.load(f)
+              totals = coverage_data.get('totals', {}) if isinstance(coverage_data, dict) else {}
+              if isinstance(totals, dict):
+                  coverage_percent = float(totals.get('percent_covered', 0) or 0)
+              print(f'Coverage percent from pr_coverage.json: {coverage_percent:.2f}%')
+          except FileNotFoundError:
+              print('Coverage file pr_coverage.json not found. Defaulting coverage to 0.00%.')
+          except Exception as e:
+              print(f'Error processing coverage data: {e}')
               
           except FileNotFoundError as e:
               print(f'File not found error: {e}')
@@ -300,6 +314,7 @@ jobs:
           print(f'Total tests: {pr_total}')
           print(f'Passed tests: {pr_passed}')
           print(f'Pass percentage: {pr_percentage:.2f}%')
+          print(f'Coverage percent: {coverage_percent:.2f}%')
           print(f'Failing tests: {len(failing_tests)}')
           print(f'Skipped tests: {len(skipped_tests)}')
           print(f'Xfailed tests: {len(xfailed_tests)}')
@@ -313,6 +328,7 @@ jobs:
               f.write(f'failing_count={len(failing_tests)}\\n')
               f.write(f'skipped_count={len(skipped_tests)}\\n')
               f.write(f'xfailed_count={len(xfailed_tests)}\\n')
+              f.write(f'coverage={coverage_percent:.2f}\\n')
 
           # Extract warnings from test output
           warnings_list = []
@@ -362,7 +378,8 @@ jobs:
               'all_tests': all_tests,
               'skipped_tests_with_reasons': skipped_tests_with_reasons,
               'xfailed_tests_with_reasons': xfailed_tests_with_reasons,
-              'warnings': warnings_list
+              'warnings': warnings_list,
+              'coverage_percent': coverage_percent
           }
 
           with open('pr_test_data.json', 'w') as f:
@@ -383,6 +400,7 @@ jobs:
             pr_test_data.json
             test_output.txt
             pr_results.json
+            pr_coverage.json
           retention-days: 3
           if-no-files-found: ignore
 
@@ -398,6 +416,7 @@ jobs:
       error_type: ${{ steps.check-collection.outputs.error_type }}
       error_details: ${{ steps.check-collection.outputs.error_details }}
       passing_count: ${{ steps.check-collection.outputs.has_collection_errors == 'true' && steps.set-error-outputs.outputs.passing_count || steps.extract-results.outputs.passing_count }}
+      coverage: ${{ steps.check-collection.outputs.has_collection_errors == 'true' && steps.set-error-outputs.outputs.coverage || steps.extract-results.outputs.coverage }}
 
     steps:
       - name: Checkout target branch
@@ -414,7 +433,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-json-report pytest-asyncio
+          pip install pytest pytest-json-report pytest-asyncio pytest-cov
           if [ -f requirements.txt ]; then 
             pip install -r requirements.txt
           fi
@@ -508,7 +527,7 @@ jobs:
         if: steps.check-collection.outputs.has_collection_errors != 'true'
         run: |
           echo "Running tests on target branch..."
-          python -m pytest -vv --json-report --json-report-file=target_results.json --tb=short > target_test_output.txt 2>&1 || true
+          python -m pytest -vv --json-report --json-report-file=target_results.json --tb=short --cov=. --cov-report=term --cov-report=json:target_coverage.json > target_test_output.txt 2>&1 || true
 
           if [ -f target_results.json ]; then
             echo "✅ Test execution completed"
@@ -592,6 +611,18 @@ jobs:
               # Calculate percentage safely
               target_percentage = (target_passed / target_total * 100) if target_total > 0 else 0
               print(f'Pass percentage calculated: {target_percentage:.2f}%')
+
+          try:
+              with open('target_coverage.json') as f:
+                  coverage_data = json.load(f)
+              totals = coverage_data.get('totals', {}) if isinstance(coverage_data, dict) else {}
+              if isinstance(totals, dict):
+                  coverage_percent = float(totals.get('percent_covered', 0) or 0)
+              print(f'Coverage percent from target_coverage.json: {coverage_percent:.2f}%')
+          except FileNotFoundError:
+              print('Coverage file target_coverage.json not found. Defaulting coverage to 0.00%.')
+          except Exception as e:
+              print(f'Error processing coverage data: {e}')
               
           except FileNotFoundError as e:
               print(f'File not found error: {e}')
@@ -609,6 +640,7 @@ jobs:
           print(f'Total tests: {target_total}')
           print(f'Passed tests: {target_passed}')
           print(f'Pass percentage: {target_percentage:.2f}%')
+          print(f'Coverage percent: {coverage_percent:.2f}%')
           print(f'Passing tests: {len(passing_tests)}')
           print(f'All discovered tests: {len(all_tests)}')
 
@@ -618,6 +650,7 @@ jobs:
               f.write(f'passed={target_passed}\\n')
               f.write(f'percentage={target_percentage:.2f}\\n')
               f.write(f'passing_count={len(passing_tests)}\\n')
+              f.write(f'coverage={coverage_percent:.2f}\\n')
 
           # Extract warnings from test output
           warnings_list = []
@@ -665,7 +698,8 @@ jobs:
               'skipped_tests': skipped_tests,
               'xfailed_tests': xfailed_tests,
               'all_tests': all_tests,
-              'warnings': warnings_list
+              'warnings': warnings_list,
+              'coverage_percent': coverage_percent
           }
 
           with open('target_test_data.json', 'w') as f:
@@ -689,6 +723,7 @@ jobs:
             target_test_data.json
             target_test_output.txt
             target_results.json
+            target_coverage.json
           retention-days: 3
           if-no-files-found: ignore
 
@@ -702,6 +737,7 @@ jobs:
           echo "passed=0" >> $GITHUB_OUTPUT
           echo "percentage=0.00" >> $GITHUB_OUTPUT
           echo "passing_count=0" >> $GITHUB_OUTPUT
+          echo "coverage=0.00" >> $GITHUB_OUTPUT
 
   compare-results:
     needs: [test-source-branch, test-target-branch]
@@ -802,13 +838,26 @@ jobs:
               pass_to_fail = list(target_passing.intersection(pr_failing))
               pass_to_skip = list(target_passing.intersection(pr_skipped.union(pr_xfailed)))
               fail_to_skip = list(target_failing.intersection(pr_skipped))
+              fail_to_pass = list(target_failing.intersection(pr_passing))
+              skip_to_pass = list(target_skipped.intersection(pr_passing))
+              xfail_to_pass = list(target_xfailed.intersection(pr_passing))
               pass_to_gone = list(target_passing - pr_all_tests)  # Passing tests that completely disappeared
               fail_to_gone = list(target_failing - pr_all_tests)  # Failing tests that completely disappeared
-              discovery_regressions = list(pr_warnings - target_warnings)
+              new_tests = list(pr_all_tests - target_all_tests)
+              removed_tests = list(target_all_tests - pr_all_tests)
+              new_discovery_warnings = list(pr_warnings - target_warnings)
+              resolved_discovery_warnings = list(target_warnings - pr_warnings)
 
               # Create comprehensive regression report
-              has_any_regressions = bool(pass_to_fail or pass_to_skip or pass_to_gone or fail_to_gone or discovery_regressions)
-              has_improvements = bool(fail_to_skip)
+              has_any_regressions = bool(pass_to_fail or pass_to_skip or pass_to_gone or fail_to_gone or new_discovery_warnings)
+              has_improvements = bool(
+                  fail_to_skip
+                  or fail_to_pass
+                  or skip_to_pass
+                  or xfail_to_pass
+                  or resolved_discovery_warnings
+                  or new_tests
+              )
               
               with open("comprehensive_regression_report.txt", "w") as f:
                   f.write("COMPREHENSIVE REGRESSION ANALYSIS\n")
@@ -828,37 +877,79 @@ jobs:
                           f.write(f"  {i}. {test}\n")
                       f.write("\n")
                   
+                  if pass_to_gone:
+                      f.write(f"PASS-TO-GONE REGRESSIONS ({len(pass_to_gone)} tests)\n")
+                      f.write("Previously passing, now missing entirely from PR branch:\n")
+                      for i, test in enumerate(sorted(pass_to_gone), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+
+                  if fail_to_gone:
+                      f.write(f"FAIL-TO-GONE REGRESSIONS ({len(fail_to_gone)} tests)\n")
+                      f.write("Previously failing, now missing entirely from PR branch:\n")
+                      for i, test in enumerate(sorted(fail_to_gone), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+
+                  if new_discovery_warnings:
+                      f.write(f"NEW DISCOVERY WARNINGS ({len(new_discovery_warnings)} warnings)\n")
+                      f.write("New warnings introduced in PR branch:\n")
+                      for i, warning in enumerate(sorted(new_discovery_warnings), 1):
+                          f.write(f"  {i}. {warning[:200]}\n")
+                      f.write("\n")
+
+                  if removed_tests:
+                      f.write(f"REMOVED TESTS ({len(removed_tests)} tests)\n")
+                      f.write("Tests present in target branch but missing from PR branch:\n")
+                      for i, test in enumerate(sorted(removed_tests), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+
                   if fail_to_skip:
                       f.write(f"FAIL-TO-SKIP IMPROVEMENTS ({len(fail_to_skip)} tests)\n")
                       f.write("Previously failing, now skipped (treated as improvements):\n")
                       for i, test in enumerate(sorted(fail_to_skip), 1):
                           f.write(f"  {i}. {test}\n")
                       f.write("\n")
-                  
-                  if pass_to_gone:
-                      f.write(f"PASS-TO-GONE REGRESSIONS ({len(pass_to_gone)} tests)\n")
-                      f.write("Previously passing, now completely missing:\n")
-                      for i, test in enumerate(sorted(pass_to_gone), 1):
+
+                  if fail_to_pass:
+                      f.write(f"FAIL-TO-PASS IMPROVEMENTS ({len(fail_to_pass)} tests)\n")
+                      f.write("Previously failing, now passing:\n")
+                      for i, test in enumerate(sorted(fail_to_pass), 1):
                           f.write(f"  {i}. {test}\n")
                       f.write("\n")
-                  
-                  if fail_to_gone:
-                      f.write(f"FAIL-TO-GONE REGRESSIONS ({len(fail_to_gone)} tests)\n")
-                      f.write("Previously failing, now completely missing:\n")
-                      for i, test in enumerate(sorted(fail_to_gone), 1):
+
+                  if skip_to_pass:
+                      f.write(f"SKIP-TO-PASS IMPROVEMENTS ({len(skip_to_pass)} tests)\n")
+                      f.write("Previously skipped, now passing:\n")
+                      for i, test in enumerate(sorted(skip_to_pass), 1):
                           f.write(f"  {i}. {test}\n")
                       f.write("\n")
-                  
-                  if discovery_regressions:
-                      f.write(f"DISCOVERY REGRESSIONS ({len(discovery_regressions)} warnings)\n")
-                      f.write("New warnings not present in target branch:\n")
-                      for i, warning in enumerate(sorted(discovery_regressions), 1):
-                          f.write(f"  {i}. {warning[:200]}...\n")
+
+                  if xfail_to_pass:
+                      f.write(f"XFAIL-TO-PASS IMPROVEMENTS ({len(xfail_to_pass)} tests)\n")
+                      f.write("Previously xfailed, now passing:\n")
+                      for i, test in enumerate(sorted(xfail_to_pass), 1):
+                          f.write(f"  {i}. {test}\n")
                       f.write("\n")
-                  
+
+                  if resolved_discovery_warnings:
+                      f.write(f"RESOLVED DISCOVERY WARNINGS ({len(resolved_discovery_warnings)} warnings)\n")
+                      f.write("Warnings present in target branch but resolved in PR branch:\n")
+                      for i, warning in enumerate(sorted(resolved_discovery_warnings), 1):
+                          f.write(f"  {i}. {warning[:200]}\n")
+                      f.write("\n")
+
+                  if new_tests:
+                      f.write(f"NEW TESTS ({len(new_tests)} tests)\n")
+                      f.write("Tests introduced in PR branch:\n")
+                      for i, test in enumerate(sorted(new_tests), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+
                   if not has_any_regressions:
                       if has_improvements:
-                          f.write("No regressions detected across all categories. Previously failing tests transitioned to skipped (treated as improvements).\n")
+                          f.write("No regressions detected across all categories. Previously failing tests transitioned to skipped/passing or warnings were resolved (treated as improvements).\n")
                       else:
                           f.write("No regressions detected across all categories.\n")
               
@@ -870,21 +961,64 @@ jobs:
                           f.write(f"{idx}. {test}\n")
               
               # Print summary
-              print(f"📊 Regression Analysis Results:")
+              print("📊 Regression Analysis Results:")
               print(f"  Pass-to-Fail: {len(pass_to_fail)} tests")
               print(f"  Pass-to-Skip: {len(pass_to_skip)} tests")
-              print(f"  Fail-to-Skip (improvements): {len(fail_to_skip)} tests")
               print(f"  Pass-to-Gone: {len(pass_to_gone)} tests")
               print(f"  Fail-to-Gone: {len(fail_to_gone)} tests")
-              print(f"  Discovery: {len(discovery_regressions)} warnings")
-              
+              print(f"  New Discovery Warnings: {len(new_discovery_warnings)} warnings")
+              print(f"  Removed Tests: {len(removed_tests)} tests")
+              print(f"  Fail-to-Skip Improvements: {len(fail_to_skip)} tests")
+              print(f"  Fail-to-Pass Improvements: {len(fail_to_pass)} tests")
+              print(f"  Skip-to-Pass Improvements: {len(skip_to_pass)} tests")
+              print(f"  XFail-to-Pass Improvements: {len(xfail_to_pass)} tests")
+              print(f"  Resolved Discovery Warnings: {len(resolved_discovery_warnings)} warnings")
+              print(f"  New Tests: {len(new_tests)} tests")
+
+              total_regressions = len(pass_to_fail) + len(pass_to_skip) + len(pass_to_gone) + len(fail_to_gone) + len(new_discovery_warnings)
+              total_improvements = (
+                  len(fail_to_skip)
+                  + len(fail_to_pass)
+                  + len(skip_to_pass)
+                  + len(xfail_to_pass)
+                  + len(resolved_discovery_warnings)
+              )
+
               if has_any_regressions:
-                  print(f"❌ Total regressions detected: {len(pass_to_fail) + len(pass_to_skip) + len(pass_to_gone) + len(fail_to_gone) + len(discovery_regressions)}")
+                  print(f"❌ Total regressions detected: {total_regressions}")
               else:
                   if has_improvements:
-                      print(f"✅ No regressions detected. {len(fail_to_skip)} failing test(s) are now skipped (treated as improvements).")
+                      print(
+                          "✅ No regressions detected. Improvements identified across failing, skipped, or warning scenarios."
+                      )
                   else:
                       print("✅ No regressions detected")
+
+              metrics = {
+                  "pass_to_fail": len(pass_to_fail),
+                  "pass_to_skip": len(pass_to_skip),
+                  "pass_to_gone": len(pass_to_gone),
+                  "fail_to_gone": len(fail_to_gone),
+                  "new_discovery_warnings": len(new_discovery_warnings),
+                  "removed_tests": len(removed_tests),
+                  "fail_to_skip": len(fail_to_skip),
+                  "fail_to_pass": len(fail_to_pass),
+                  "skip_to_pass": len(skip_to_pass),
+                  "xfail_to_pass": len(xfail_to_pass),
+                  "resolved_discovery_warnings": len(resolved_discovery_warnings),
+                  "new_tests": len(new_tests),
+                  "total_regressions": total_regressions,
+                  "total_improvements": total_improvements,
+              }
+
+              with open("comparison_metrics.json", "w") as metrics_file:
+                  json.dump(metrics, metrics_file, indent=2)
+
+              env_path = os.environ.get("GITHUB_ENV")
+              if env_path:
+                  with open(env_path, "a") as env_file:
+                      for key, value in metrics.items():
+                          env_file.write(f"{key.upper()}_COUNT={value}\n")
                   
           except Exception as e:
               print(f"Error in regression analysis: {e}")
@@ -942,6 +1076,7 @@ jobs:
           path: |
             regression_details.txt
             comprehensive_regression_report.txt
+            comparison_metrics.json
           retention-days: 1
           if-no-files-found: ignore
 
@@ -1011,176 +1146,245 @@ jobs:
 
       - name: Compare test results
         run: |
-          echo "Target: ${{ needs.test-target-branch.outputs.passed }}/${{ needs.test-target-branch.outputs.total }} passed (${{ needs.test-target-branch.outputs.percentage }}%)"
-          echo "PR: ${{ needs.test-source-branch.outputs.passed }}/${{ needs.test-source-branch.outputs.total }} passed (${{ needs.test-source-branch.outputs.percentage }}%)"
+          export PR_TOTAL="${{ needs.test-source-branch.outputs.total }}"
+          export PR_PASSED="${{ needs.test-source-branch.outputs.passed }}"
+          export PR_PERCENTAGE="${{ needs.test-source-branch.outputs.percentage }}"
+          export PR_COVERAGE="${{ needs.test-source-branch.outputs.coverage }}"
+          export TARGET_TOTAL="${{ needs.test-target-branch.outputs.total }}"
+          export TARGET_PASSED="${{ needs.test-target-branch.outputs.passed }}"
+          export TARGET_PERCENTAGE="${{ needs.test-target-branch.outputs.percentage }}"
+          export TARGET_COVERAGE="${{ needs.test-target-branch.outputs.coverage }}"
+          export META_HAS_REGRESSIONS="${{ needs.perform-regression-analysis.outputs.has_regressions }}"
+          export META_REGRESSION_COUNT="${{ needs.perform-regression-analysis.outputs.regression_count }}"
 
-          if [[ "${{ needs.test-source-branch.outputs.total }}" == "0" ]]; then
-            echo "::error::No tests were found in the PR branch"
-            echo "❌ PR branch has no tests detected. Please add test files that match pytest's discovery pattern."
-            exit 1
-          fi
+          python - <<'PY'
+import json
+import os
+import pathlib
+import sys
 
-          PR_PASSED=${{ needs.test-source-branch.outputs.passed }}
-          TARGET_PASSED=${{ needs.test-target-branch.outputs.passed }}
-          PR_PERCENTAGE=${{ needs.test-source-branch.outputs.percentage }}
-          TARGET_PERCENTAGE=${{ needs.test-target-branch.outputs.percentage }}
-          PR_TOTAL=${{ needs.test-source-branch.outputs.total }}
-          TARGET_TOTAL=${{ needs.test-target-branch.outputs.total }}
 
-          # Handle case where target has no tests
-          if [[ "$TARGET_TOTAL" == "0" ]]; then
-            if [[ "$PR_PASSED" -gt 0 ]]; then
-              echo "✅ PR branch has tests and some are passing (target branch has no tests)"
-              exit 0
-            else
-              echo "❌ PR branch has no passing tests"
-              echo "  - Pass percentage: $PR_PERCENTAGE%"
-              exit 1
-            fi
-          fi
+def as_float(value: object) -> float:
+    try:
+        if value is None:
+            return 0.0
+        text = str(value).strip()
+        if not text:
+            return 0.0
+        return float(text)
+    except (TypeError, ValueError):
+        return 0.0
 
-          # Check for regressions from meta-regression-analysis OR our comprehensive analysis
-          COMPREHENSIVE_REGRESSIONS="false"
-          if [ -f comprehensive_regression_report.txt ]; then
-            # Check if there are any actual regressions in our comprehensive report
-            if grep -q "REGRESSIONS.*([1-9]" comprehensive_regression_report.txt; then
-              COMPREHENSIVE_REGRESSIONS="true"
-            fi
-          fi
 
-          if [[ "${{ needs.perform-regression-analysis.outputs.has_regressions }}" == "true" ]] || [[ "$COMPREHENSIVE_REGRESSIONS" == "true" ]]; then
-            echo "❌ Test regressions detected from target branch"
-            REGRESSION_COUNT_VAL=${{ needs.perform-regression-analysis.outputs.regression_count }}
+def as_int(value: object) -> int:
+    try:
+        if value is None:
+            return 0
+        text = str(value).strip()
+        if not text:
+            return 0
+        return int(float(text))
+    except (TypeError, ValueError):
+        return 0
 
-            echo "### :x: Test Regressions Detected!" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            
-            # Extract counts from comprehensive report if available
-            if [ -f comprehensive_regression_report.txt ]; then
-              PASS_FAIL_COUNT=$(grep -o "PASS-TO-FAIL REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              PASS_SKIP_COUNT=$(grep -o "PASS-TO-SKIP REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              FAIL_SKIP_IMPROVEMENTS_COUNT=$(grep -o "FAIL-TO-SKIP IMPROVEMENTS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              PASS_GONE_COUNT=$(grep -o "PASS-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              FAIL_GONE_COUNT=$(grep -o "FAIL-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              DISCOVERY_COUNT=$(grep -o "DISCOVERY REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
 
-              TOTAL_REGRESSIONS=$((PASS_FAIL_COUNT + PASS_SKIP_COUNT + PASS_GONE_COUNT + FAIL_GONE_COUNT + DISCOVERY_COUNT))
+def format_delta(delta: float, is_percentage: bool = False) -> str:
+    if is_percentage:
+        return f"{delta:+.2f}%"
+    if delta == int(delta):
+        return f"{int(delta):+d}"
+    return f"{delta:+.2f}"
 
-              echo "**$TOTAL_REGRESSIONS total regression(s) detected across multiple categories:**" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| Category | Count |" >> $GITHUB_STEP_SUMMARY
-              echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-              echo "| Pass → Fail | $PASS_FAIL_COUNT |" >> $GITHUB_STEP_SUMMARY
-              echo "| Pass → Skip/XFail | $PASS_SKIP_COUNT |" >> $GITHUB_STEP_SUMMARY
-              echo "| Pass → Gone | $PASS_GONE_COUNT |" >> $GITHUB_STEP_SUMMARY
-              echo "| Fail → Gone | $FAIL_GONE_COUNT |" >> $GITHUB_STEP_SUMMARY
-              echo "| Discovery Warnings | $DISCOVERY_COUNT |" >> $GITHUB_STEP_SUMMARY
-              if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
-                echo "| Fail → Skip (Improvement) | $FAIL_SKIP_IMPROVEMENTS_COUNT |" >> $GITHUB_STEP_SUMMARY
-              fi
-              echo "" >> $GITHUB_STEP_SUMMARY
-              if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
-                echo "_Note: Fail → Skip transitions are treated as improvements and do not cause this job to fail._" >> $GITHUB_STEP_SUMMARY
-                echo "" >> $GITHUB_STEP_SUMMARY
-              fi
-            else
-              echo "**$REGRESSION_COUNT_VAL test regression(s) detected.** See detailed breakdown below:" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
 
-            # Display comprehensive regression report if available
-            if [ -f comprehensive_regression_report.txt ]; then
-                echo "📋 **Comprehensive Regression Analysis:**" >> $GITHUB_STEP_SUMMARY
-                echo "" >> $GITHUB_STEP_SUMMARY
-                
-                # Parse and format the comprehensive report for better GitHub display
-                while IFS= read -r line; do
-                    if [[ "$line" =~ ^[A-Z-].*(REGRESSIONS|IMPROVEMENTS).*(\([0-9]+) ]]; then
-                        echo "### $line" >> $GITHUB_STEP_SUMMARY
-                    elif [[ "$line" =~ ^Previously ]]; then
-                        echo "*$line*" >> $GITHUB_STEP_SUMMARY
-                        echo "" >> $GITHUB_STEP_SUMMARY
-                    elif [[ "$line" =~ ^[[:space:]]*[0-9]+\. ]]; then
-                        echo "- ${line#*. }" >> $GITHUB_STEP_SUMMARY
-                    elif [[ ! "$line" =~ ^=.*=$ ]] && [[ -n "$line" ]]; then
-                        echo "$line" >> $GITHUB_STEP_SUMMARY
-                    fi
-                done < comprehensive_regression_report.txt
-                
-                echo "" >> $GITHUB_STEP_SUMMARY
-            elif [ -f regression_details.txt ]; then
-                echo "### Pass-to-Fail Regressions" >> $GITHUB_STEP_SUMMARY
-                echo "" >> $GITHUB_STEP_SUMMARY
-                grep "^[0-9]\+\." regression_details.txt | while read -r line; do
-                    echo "- ${line#*. }" >> $GITHUB_STEP_SUMMARY
-                done
-                echo "" >> $GITHUB_STEP_SUMMARY
-            else
-                echo "::warning::Regression details files not found."
-            fi
-            
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This job (\`compare-results\`) has been marked as failed due to these regressions." >> $GITHUB_STEP_SUMMARY
-            exit 1
-          fi
+pr_total = as_int(os.environ.get("PR_TOTAL"))
+pr_passed = as_int(os.environ.get("PR_PASSED"))
+pr_percentage = as_float(os.environ.get("PR_PERCENTAGE"))
+pr_coverage = as_float(os.environ.get("PR_COVERAGE"))
+target_total = as_int(os.environ.get("TARGET_TOTAL"))
+target_passed = as_int(os.environ.get("TARGET_PASSED"))
+target_percentage = as_float(os.environ.get("TARGET_PERCENTAGE"))
+target_coverage = as_float(os.environ.get("TARGET_COVERAGE"))
+meta_has_regressions = os.environ.get("META_HAS_REGRESSIONS", "").lower() == "true"
+meta_regression_count = as_int(os.environ.get("META_REGRESSION_COUNT"))
 
-          # Highlight improvements in the summary even when no regressions were found
-          if [ -f comprehensive_regression_report.txt ]; then
-            FAIL_SKIP_IMPROVEMENTS_COUNT=$(grep -o "FAIL-TO-SKIP IMPROVEMENTS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+metrics_path = pathlib.Path("comparison_metrics.json")
+metrics = {}
+if metrics_path.exists():
+    try:
+        metrics = json.loads(metrics_path.read_text())
+    except json.JSONDecodeError:
+        metrics = {}
 
-            if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
-              echo "### ✅ Test Improvements Detected" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| Category | Count |" >> $GITHUB_STEP_SUMMARY
-              echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-              echo "| Fail → Skip (Improvement) | $FAIL_SKIP_IMPROVEMENTS_COUNT |" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "_Note: Fail → Skip transitions are treated as improvements and do not cause this job to fail._" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-          fi
+metric_keys = [
+    "pass_to_fail",
+    "pass_to_skip",
+    "pass_to_gone",
+    "fail_to_gone",
+    "new_discovery_warnings",
+    "removed_tests",
+    "fail_to_skip",
+    "fail_to_pass",
+    "skip_to_pass",
+    "xfail_to_pass",
+    "resolved_discovery_warnings",
+    "new_tests",
+    "total_regressions",
+    "total_improvements",
+]
 
-          # Continue with the original comparison if no regressions
-          if (( $(echo "$PR_PASSED >= $TARGET_PASSED" | bc -l) )) && (( $(echo "$PR_PERCENTAGE >= $TARGET_PERCENTAGE" | bc -l) )); then
-            echo "✅ PR branch has equal or better test results than target branch"
-            
-            # Additional verbose information about improvement
-            if (( $(echo "$PR_PASSED > $TARGET_PASSED" | bc -l) )); then
-              IMPROVEMENT=$(( $PR_PASSED - $TARGET_PASSED ))
-              echo "  - Improvement: $IMPROVEMENT more passing tests than target branch"
-            fi
-            
-            if (( $(echo "$PR_PERCENTAGE > $TARGET_PERCENTAGE" | bc -l) )); then
-              PERCENTAGE_IMPROVEMENT=$(echo "$PR_PERCENTAGE - $TARGET_PERCENTAGE" | bc -l)
-              echo "  - Percentage improvement: +${PERCENTAGE_IMPROVEMENT}% compared to target branch"
-            fi
-            
-            exit 0
-          else
-            echo "❌ PR branch has worse test results than target branch"
-            echo "  - Passed tests: $PR_PASSED vs $TARGET_PASSED on target branch"
-            echo "  - Pass percentage: $PR_PERCENTAGE% vs $TARGET_PERCENTAGE% on target branch"
-            
-            # Add to job summary for general comparison failure
-            echo "### :x: Test Comparison Failed" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The PR branch has worse test results than the target branch:" >> $GITHUB_STEP_SUMMARY
-            echo "- Passed tests: $PR_PASSED (PR) vs $TARGET_PASSED (Target)" >> $GITHUB_STEP_SUMMARY
-            echo "- Pass percentage: $PR_PERCENTAGE% (PR) vs $TARGET_PERCENTAGE% (Target)" >> $GITHUB_STEP_SUMMARY
-            
-            # Calculate regression metrics
-            if (( $(echo "$PR_PASSED < $TARGET_PASSED" | bc -l) )); then
-              REGRESSION=$(( $TARGET_PASSED - $PR_PASSED ))
-              echo "  - Regression: $REGRESSION fewer passing tests than target branch"
-            fi
-            
-            if (( $(echo "$PR_PERCENTAGE < $TARGET_PERCENTAGE" | bc -l) )); then
-              PERCENTAGE_REGRESSION=$(echo "$TARGET_PERCENTAGE - $PR_PERCENTAGE" | bc -l)
-              echo "  - Percentage regression: -${PERCENTAGE_REGRESSION}% compared to target branch"
-            fi
-            
-            exit 1
-          fi
+for key in metric_keys:
+    env_value = os.environ.get(f"{key.upper()}_COUNT")
+    if key not in metrics or not isinstance(metrics.get(key), (int, float)):
+        metrics[key] = as_int(env_value)
+
+total_regressions = metrics.get("total_regressions", 0)
+total_improvements = metrics.get("total_improvements", 0)
+
+if total_regressions == 0 and meta_regression_count > 0:
+    total_regressions = meta_regression_count
+    metrics["total_regressions"] = total_regressions
+
+coverage_delta = pr_coverage - target_coverage
+percentage_delta = pr_percentage - target_percentage
+passed_delta = pr_passed - target_passed
+total_delta = pr_total - target_total
+
+coverage_drop = target_coverage > 0 and coverage_delta < -0.01
+percentage_drop = target_total > 0 and percentage_delta < -0.01
+passed_drop = target_total > 0 and passed_delta < 0
+
+fail_reasons: list[str] = []
+
+if pr_total == 0:
+    fail_reasons.append("PR branch has no tests detected. Please ensure pytest discovers tests.")
+
+if target_total == 0:
+    if pr_passed <= 0:
+        fail_reasons.append("PR branch has no passing tests while target branch has none to compare against.")
+else:
+    if passed_drop:
+        fail_reasons.append(
+            f"PR branch has {abs(passed_delta)} fewer passing tests than the target branch."
+        )
+    if percentage_drop:
+        fail_reasons.append(
+            f"PR branch pass percentage dropped by {abs(percentage_delta):.2f} percentage points."
+        )
+
+if meta_has_regressions or total_regressions > 0:
+    regression_count = total_regressions if total_regressions else meta_regression_count
+    fail_reasons.append(f"{regression_count} test regression(s) detected compared to the target branch.")
+
+if coverage_drop:
+    fail_reasons.append(
+        f"Test coverage decreased by {abs(coverage_delta):.2f} percentage points (target {target_coverage:.2f}%, PR {pr_coverage:.2f}%)."
+    )
+
+status_emoji = "❌" if fail_reasons else "✅"
+status_text = "Issues detected" if fail_reasons else "All checks passed"
+
+print(
+    f"Target: {target_passed}/{target_total} passed ({target_percentage:.2f}%), coverage {target_coverage:.2f}%"
+)
+print(
+    f"PR: {pr_passed}/{pr_total} passed ({pr_percentage:.2f}%), coverage {pr_coverage:.2f}%"
+)
+print(f"Pass delta: {format_delta(passed_delta)}")
+print(f"Pass percentage delta: {format_delta(percentage_delta, is_percentage=True)}")
+print(f"Coverage delta: {format_delta(coverage_delta, is_percentage=True)}")
+
+summary_path = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+with summary_path.open("a", encoding="utf-8") as summary:
+    summary.write(f"### {status_emoji} {status_text}\n\n")
+    summary.write("| Metric | Target | PR | Δ |\n")
+    summary.write("|--------|--------|----|---|\n")
+    summary.write(
+        f"| Total Tests | {target_total} | {pr_total} | {format_delta(total_delta)} |\n"
+    )
+    summary.write(
+        f"| Passed Tests | {target_passed} | {pr_passed} | {format_delta(passed_delta)} |\n"
+    )
+    summary.write(
+        f"| Pass Percentage | {target_percentage:.2f}% | {pr_percentage:.2f}% | {format_delta(percentage_delta, True)} |\n"
+    )
+    summary.write(
+        f"| Coverage | {target_coverage:.2f}% | {pr_coverage:.2f}% | {format_delta(coverage_delta, True)} |\n"
+    )
+    summary.write("\n")
+
+    summary.write("#### Regression Overview\n\n")
+    summary.write("| Category | Count |\n")
+    summary.write("|----------|-------|\n")
+    summary.write(
+        f"| Pass → Fail | {metrics.get('pass_to_fail', 0)} |\n"
+    )
+    summary.write(
+        f"| Pass → Skip/XFail | {metrics.get('pass_to_skip', 0)} |\n"
+    )
+    summary.write(
+        f"| Pass → Gone | {metrics.get('pass_to_gone', 0)} |\n"
+    )
+    summary.write(
+        f"| Fail → Gone | {metrics.get('fail_to_gone', 0)} |\n"
+    )
+    summary.write(
+        f"| Removed Tests | {metrics.get('removed_tests', 0)} |\n"
+    )
+    summary.write(
+        f"| New Discovery Warnings | {metrics.get('new_discovery_warnings', 0)} |\n"
+    )
+    summary.write("\n")
+
+    summary.write("#### Improvements & Additions\n\n")
+    summary.write("| Category | Count |\n")
+    summary.write("|----------|-------|\n")
+    summary.write(
+        f"| Fail → Skip | {metrics.get('fail_to_skip', 0)} |\n"
+    )
+    summary.write(
+        f"| Fail → Pass | {metrics.get('fail_to_pass', 0)} |\n"
+    )
+    summary.write(
+        f"| Skip → Pass | {metrics.get('skip_to_pass', 0)} |\n"
+    )
+    summary.write(
+        f"| XFail → Pass | {metrics.get('xfail_to_pass', 0)} |\n"
+    )
+    summary.write(
+        f"| Resolved Discovery Warnings | {metrics.get('resolved_discovery_warnings', 0)} |\n"
+    )
+    summary.write(
+        f"| New Tests | {metrics.get('new_tests', 0)} |\n"
+    )
+    summary.write("\n")
+
+    if fail_reasons:
+        summary.write("#### Issues Detected\n\n")
+        for reason in fail_reasons:
+            summary.write(f"- {reason}\n")
+        summary.write("\n")
+    else:
+        summary.write(
+            "All checks passed with no regressions, coverage drops, or pass-rate degradations compared to the target branch.\n\n"
+        )
+
+    report_path = pathlib.Path("comprehensive_regression_report.txt")
+    if total_regressions > 0 and report_path.exists():
+        summary.write("<details>\n")
+        summary.write("<summary>View comprehensive regression report</summary>\n\n")
+        summary.write("```\n")
+        summary.write(report_path.read_text())
+        summary.write("\n```\n")
+        summary.write("</details>\n\n")
+
+if fail_reasons:
+    for reason in fail_reasons:
+        print(f"::error::{reason}")
+    sys.exit(1)
+
+print("✅ Test comparison succeeded without regressions or coverage drops.")
+sys.exit(0)
+PY
 
   perform-regression-analysis:
     needs: [test-source-branch, test-target-branch]
@@ -1275,9 +1479,11 @@ jobs:
           PR_TOTAL_TESTS: ${{ needs.test-source-branch.outputs.total }}
           PR_PASSED_TESTS: ${{ needs.test-source-branch.outputs.passed }}
           PR_PERCENTAGE: ${{ needs.test-source-branch.outputs.percentage }}
+          PR_COVERAGE: ${{ needs.test-source-branch.outputs.coverage }}
           TARGET_TOTAL_TESTS: ${{ needs.test-target-branch.outputs.total }}
           TARGET_PASSED_TESTS: ${{ needs.test-target-branch.outputs.passed }}
           TARGET_PERCENTAGE: ${{ needs.test-target-branch.outputs.percentage }}
+          TARGET_COVERAGE: ${{ needs.test-target-branch.outputs.coverage }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -1445,100 +1651,72 @@ jobs:
           fi
 
           # Regression Analysis Summary
-          if [[ "$HAS_REGRESSIONS" == "true" ]]; then
+          PASS_FAIL_COUNT=${PASS_TO_FAIL_COUNT:-0}
+          PASS_SKIP_COUNT=${PASS_TO_SKIP_COUNT:-0}
+          PASS_GONE_COUNT=${PASS_TO_GONE_COUNT:-0}
+          FAIL_GONE_COUNT=${FAIL_TO_GONE_COUNT:-0}
+          NEW_DISCOVERY_COUNT=${NEW_DISCOVERY_WARNINGS_COUNT:-0}
+          REMOVED_TESTS_COUNT=${REMOVED_TESTS_COUNT:-0}
+          FAIL_SKIP_COUNT=${FAIL_TO_SKIP_COUNT:-0}
+          FAIL_PASS_COUNT=${FAIL_TO_PASS_COUNT:-0}
+          SKIP_PASS_COUNT=${SKIP_TO_PASS_COUNT:-0}
+          XFAIL_PASS_COUNT=${XFAIL_TO_PASS_COUNT:-0}
+          RESOLVED_WARNINGS_COUNT=${RESOLVED_DISCOVERY_WARNINGS_COUNT:-0}
+          NEW_TESTS_COUNT=${NEW_TESTS_COUNT:-0}
+          TOTAL_REGRESSIONS=${TOTAL_REGRESSIONS_COUNT:-0}
+          TOTAL_IMPROVEMENTS=${TOTAL_IMPROVEMENTS_COUNT:-0}
+          META_REGRESSION_TOTAL=${REGRESSION_COUNT:-0}
+
+          if [[ "$TOTAL_REGRESSIONS" -eq 0 && "$META_REGRESSION_TOTAL" -gt 0 ]]; then
+            TOTAL_REGRESSIONS=$META_REGRESSION_TOTAL
+          fi
+
+          if [[ "$HAS_REGRESSIONS" == "true" || "$TOTAL_REGRESSIONS" -gt 0 ]]; then
             MESSAGE_LINES+=("**:red_circle: REGRESSIONS DETECTED**")
-            
-            # Check if we have comprehensive regression file with categories
-            if [ -f "comprehensive_regression_report.txt" ]; then
-              # Extract counts from comprehensive report
-              PASS_FAIL_COUNT=$(grep -o "PASS-TO-FAIL REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              PASS_SKIP_COUNT=$(grep -o "PASS-TO-SKIP REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              FAIL_SKIP_IMPROVEMENTS_COUNT=$(grep -o "FAIL-TO-SKIP IMPROVEMENTS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              PASS_GONE_COUNT=$(grep -o "PASS-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              FAIL_GONE_COUNT=$(grep -o "FAIL-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              DISCOVERY_COUNT=$(grep -o "DISCOVERY REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
-              
-                             # Add category summaries (≤5 show paths, >5 show count + refer to file)
-               if [[ "$PASS_FAIL_COUNT" -gt 0 ]]; then
-                 if [[ "$PASS_FAIL_COUNT" -le 5 ]]; then
-                   MESSAGE_LINES+=("**Pass→Fail ($PASS_FAIL_COUNT):**")
-                   readarray -t test_paths < <(grep -A 100 "PASS-TO-FAIL REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$PASS_FAIL_COUNT | sed 's/^  [0-9]\+\. //')
-                   for test_path in "${test_paths[@]}"; do
-                     MESSAGE_LINES+=("• \`$test_path\`")
-                   done
-                 else
-                   MESSAGE_LINES+=("**Pass→Fail:** $PASS_FAIL_COUNT tests (see attached file)")
-                 fi
-               fi
-               
-               if [[ "$PASS_SKIP_COUNT" -gt 0 ]]; then
-                 if [[ "$PASS_SKIP_COUNT" -le 5 ]]; then
-                   MESSAGE_LINES+=("**Pass→Skip ($PASS_SKIP_COUNT):**")
-                   readarray -t test_paths < <(grep -A 100 "PASS-TO-SKIP REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$PASS_SKIP_COUNT | sed 's/^  [0-9]\+\. //')
-                   for test_path in "${test_paths[@]}"; do
-                     MESSAGE_LINES+=("• \`$test_path\`")
-                   done
-                 else
-                   MESSAGE_LINES+=("**Pass→Skip:** $PASS_SKIP_COUNT tests (see attached file)")
-                 fi
-               fi
-               
-               if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
-                 if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -le 5 ]]; then
-                   MESSAGE_LINES+=(":white_check_mark: **Fail→Skip Improvements ($FAIL_SKIP_IMPROVEMENTS_COUNT):**")
-                   readarray -t test_paths < <(grep -A 100 "FAIL-TO-SKIP IMPROVEMENTS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$FAIL_SKIP_IMPROVEMENTS_COUNT | sed 's/^  [0-9]\+\. //')
-                   for test_path in "${test_paths[@]}"; do
-                     MESSAGE_LINES+=("• \`$test_path\`")
-                   done
-                 else
-                   MESSAGE_LINES+=(":white_check_mark: **Fail→Skip Improvements:** $FAIL_SKIP_IMPROVEMENTS_COUNT tests (see attached file)")
-                 fi
-               fi
-               
-               if [[ "$PASS_GONE_COUNT" -gt 0 ]]; then
-                 if [[ "$PASS_GONE_COUNT" -le 5 ]]; then
-                   MESSAGE_LINES+=("**Pass→Gone ($PASS_GONE_COUNT):**")
-                   readarray -t test_paths < <(grep -A 100 "PASS-TO-GONE REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$PASS_GONE_COUNT | sed 's/^  [0-9]\+\. //')
-                   for test_path in "${test_paths[@]}"; do
-                     MESSAGE_LINES+=("• \`$test_path\`")
-                   done
-                 else
-                   MESSAGE_LINES+=("**Pass→Gone:** $PASS_GONE_COUNT tests (see attached file)")
-                 fi
-               fi
-               
-               if [[ "$FAIL_GONE_COUNT" -gt 0 ]]; then
-                 if [[ "$FAIL_GONE_COUNT" -le 5 ]]; then
-                   MESSAGE_LINES+=("**Fail→Gone ($FAIL_GONE_COUNT):**")
-                   readarray -t test_paths < <(grep -A 100 "FAIL-TO-GONE REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$FAIL_GONE_COUNT | sed 's/^  [0-9]\+\. //')
-                   for test_path in "${test_paths[@]}"; do
-                     MESSAGE_LINES+=("• \`$test_path\`")
-                   done
-                 else
-                   MESSAGE_LINES+=("**Fail→Gone:** $FAIL_GONE_COUNT tests (see attached file)")
-                 fi
-               fi
-              
-              if [[ "$DISCOVERY_COUNT" -gt 0 ]]; then
-                if [[ "$DISCOVERY_COUNT" -le 5 ]]; then
-                  MESSAGE_LINES+=("**Discovery Warnings ($DISCOVERY_COUNT):**")
-                  MESSAGE_LINES+=("• $DISCOVERY_COUNT new warnings (see attached file)")
-                else
-                  MESSAGE_LINES+=("**Discovery Warnings:** $DISCOVERY_COUNT warnings (see attached file)")
-                fi
-              fi
-              
-            else
-              # Fallback to simple regression count
-              MESSAGE_LINES+=("  - **${REGRESSION_COUNT} test(s)** that were passing in \`${TARGET_BRANCH}\` are now **failing** in \`${PR_BRANCH}\`.")
-            fi
-          elif [[ "$COMPARE_RESULT" == "failure" ]] && [[ "$HAS_REGRESSIONS" != "true" ]]; then
+            MESSAGE_LINES+=("  - Pass→Fail: $PASS_FAIL_COUNT")
+            MESSAGE_LINES+=("  - Pass→Skip/XFail: $PASS_SKIP_COUNT")
+            MESSAGE_LINES+=("  - Pass→Gone: $PASS_GONE_COUNT")
+            MESSAGE_LINES+=("  - Fail→Gone: $FAIL_GONE_COUNT")
+            MESSAGE_LINES+=("  - Removed Tests: $REMOVED_TESTS_COUNT")
+            MESSAGE_LINES+=("  - New Discovery Warnings: $NEW_DISCOVERY_COUNT")
+            MESSAGE_LINES+=("  - Total Regressions: $TOTAL_REGRESSIONS")
+            MESSAGE_LINES+=("  - See attached regression report for detailed paths.")
+          fi
+
+          if (( FAIL_SKIP_COUNT > 0 || FAIL_PASS_COUNT > 0 || SKIP_PASS_COUNT > 0 || XFAIL_PASS_COUNT > 0 || RESOLVED_WARNINGS_COUNT > 0 || NEW_TESTS_COUNT > 0 )); then
+            MESSAGE_LINES+=("**:sparkles: Improvements & Additions**")
+            MESSAGE_LINES+=("  - Fail→Skip: $FAIL_SKIP_COUNT")
+            MESSAGE_LINES+=("  - Fail→Pass: $FAIL_PASS_COUNT")
+            MESSAGE_LINES+=("  - Skip→Pass: $SKIP_PASS_COUNT")
+            MESSAGE_LINES+=("  - XFail→Pass: $XFAIL_PASS_COUNT")
+            MESSAGE_LINES+=("  - Resolved Discovery Warnings: $RESOLVED_WARNINGS_COUNT")
+            MESSAGE_LINES+=("  - New Tests: $NEW_TESTS_COUNT")
+            MESSAGE_LINES+=("  - Total Improvements: $TOTAL_IMPROVEMENTS")
+          fi
+
+          COVERAGE_DROP_MESSAGE=$(python - <<'PY'
+import os
+try:
+    pr = float(os.environ.get("PR_COVERAGE", "0") or 0)
+    target = float(os.environ.get("TARGET_COVERAGE", "0") or 0)
+    delta = pr - target
+    if target > 0 and delta < -0.01:
+        print(f"Coverage dropped by {abs(delta):.2f}pp (target {target:.2f}%, PR {pr:.2f}%).")
+except Exception:
+    pass
+PY
+          )
+          if [[ -n "$COVERAGE_DROP_MESSAGE" ]]; then
+            MESSAGE_LINES+=("**:red_circle: COVERAGE DROP:** $COVERAGE_DROP_MESSAGE")
+          fi
+
+          if [[ "$COMPARE_RESULT" == "failure" ]] && [[ "$HAS_REGRESSIONS" != "true" ]] && [[ "$TOTAL_REGRESSIONS" -eq 0 ]]; then
             # This case handles general comparison failures NOT due to specific regressions
             MESSAGE_LINES+=("**:warning: TEST RESULTS DECLINED**")
             MESSAGE_LINES+=("  - The PR branch shows a decrease in test success compared to the target branch, but no specific regressions were identified by the \`meta-regression-analysis\` job.")
             MESSAGE_LINES+=("  - PR Branch (\`${PR_BRANCH}\`): **${PR_PASSED_TESTS}/${PR_TOTAL_TESTS} passed (${PR_PERCENTAGE}%)**")
             MESSAGE_LINES+=("  - Target Branch (\`${TARGET_BRANCH}\`): **${TARGET_PASSED_TESTS}/${TARGET_TOTAL_TESTS} passed (${TARGET_PERCENTAGE}%)**")
-          elif [[ "$COMPARE_RESULT" == "success" ]] && [[ "$HAS_REGRESSIONS" != "true" ]]; then
+          elif [[ "$COMPARE_RESULT" == "success" ]] && [[ "$HAS_REGRESSIONS" != "true" ]] && [[ "$TOTAL_REGRESSIONS" -eq 0 ]]; then
              MESSAGE_LINES+=("**:white_check_mark: NO REGRESSIONS DETECTED**")
              MESSAGE_LINES+=("  - PR Branch (\`${PR_BRANCH}\`): **${PR_PASSED_TESTS}/${PR_TOTAL_TESTS} passed (${PR_PERCENTAGE}%)**")
              MESSAGE_LINES+=("  - Target Branch (\`${TARGET_BRANCH}\`): **${TARGET_PASSED_TESTS}/${TARGET_TOTAL_TESTS} passed (${TARGET_PERCENTAGE}%)**")


### PR DESCRIPTION
## Summary
- collect pytest coverage for both the PR and target branches and capture it in workflow outputs
- parse coverage artifacts alongside existing test data and include them in artifacts for later jobs
- overhaul the comparison summary and notifications to report coverage deltas, regression counts, improvements, and new discovery warnings for every run

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3183079c8832eb40ce1c1236cf9a1