### PR TITLE
Add reusable workflow for dotnet test comparisons

### DIFF
--- a/.github/scripts/trx_to_pytest_json.py
+++ b/.github/scripts/trx_to_pytest_json.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Convert a .trx test report into a pytest-json-report compatible structure."""
+
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, List
+
+NS = {"ns": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+
+
+def _safe_int(value: str | None) -> int:
+    try:
+        return int(value) if value is not None else 0
+    except ValueError:
+        return 0
+
+
+def _collect_test_metadata(root: ET.Element) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for unit_test in root.findall(".//ns:UnitTest", NS):
+        test_id = unit_test.get("id") or unit_test.get("Id")
+        if not test_id:
+            continue
+        name = unit_test.get("name") or unit_test.get("Name")
+        method = unit_test.find("ns:TestMethod", NS)
+        class_name = method.get("className") if method is not None else None
+        method_name = method.get("name") if method is not None else None
+        storage = unit_test.get("storage") or unit_test.get("Storage")
+
+        parts: List[str] = []
+        if storage:
+            parts.append(Path(storage).stem)
+        if class_name:
+            parts.append(class_name)
+        if method_name:
+            parts.append(method_name)
+        elif name:
+            parts.append(name)
+
+        if parts:
+            mapping[test_id] = "::".join(parts)
+        elif name:
+            mapping[test_id] = name
+        else:
+            mapping[test_id] = test_id
+    return mapping
+
+
+def _build_test_entry(
+    result: ET.Element, id_to_name: Dict[str, str]
+) -> Dict[str, object]:
+    test_id = result.get("testId") or result.get("testID") or ""
+    display_name = id_to_name.get(
+        test_id, result.get("testName") or test_id or "unknown"
+    )
+    outcome = (result.get("outcome") or "unknown").lower()
+
+    if outcome == "notexecuted" or outcome == "inconclusive":
+        outcome_label = "skipped"
+    elif outcome == "passed":
+        outcome_label = "passed"
+    elif outcome == "failed":
+        outcome_label = "failed"
+    else:
+        outcome_label = outcome or "unknown"
+
+    longrepr: List[str] = []
+    output = result.find("ns:Output", NS)
+    if output is not None:
+        error_info = output.find("ns:ErrorInfo", NS)
+        if error_info is not None:
+            message = error_info.findtext("ns:Message", default="", namespaces=NS)
+            stack = error_info.findtext("ns:StackTrace", default="", namespaces=NS)
+            if message:
+                longrepr.append(message.strip())
+            if stack:
+                longrepr.append(stack.strip())
+
+    return {
+        "nodeid": display_name,
+        "outcome": outcome_label,
+        "longrepr": longrepr,
+    }
+
+
+def _default_report() -> Dict[str, object]:
+    return {
+        "summary": {"total": 0, "passed": 0, "failed": 0, "skipped": 0},
+        "tests": [],
+        "exitcode": 0,
+    }
+
+
+def convert_trx(trx_path: Path) -> Dict[str, object]:
+    if not trx_path.exists():
+        return _default_report()
+
+    try:
+        tree = ET.parse(trx_path)
+    except ET.ParseError:
+        return _default_report()
+
+    root = tree.getroot()
+    summary = root.find("ns:ResultSummary", NS)
+    counters = summary.find("ns:Counters", NS) if summary is not None else None
+
+    total = _safe_int(counters.get("total")) if counters is not None else 0
+    passed = _safe_int(counters.get("passed")) if counters is not None else 0
+    failed = _safe_int(counters.get("failed")) if counters is not None else 0
+    skipped = _safe_int(counters.get("notExecuted")) if counters is not None else 0
+
+    id_to_name = _collect_test_metadata(root)
+    tests = [
+        _build_test_entry(result, id_to_name)
+        for result in root.findall(".//ns:UnitTestResult", NS)
+    ]
+
+    exitcode = 0 if failed == 0 else 1
+
+    return {
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": failed,
+            "skipped": skipped,
+        },
+        "tests": tests,
+        "exitcode": exitcode,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: trx_to_pytest_json.py <input.trx> <output.json>", file=sys.stderr)
+        return 2
+
+    trx_path = Path(sys.argv[1])
+    output_path = Path(sys.argv[2])
+
+    report = convert_trx(trx_path)
+
+    output_path.write_text(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/test-cs-dotnet.yml
+++ b/.github/workflows/test-cs-dotnet.yml
@@ -1,0 +1,1595 @@
+name: Reusable Compare Dotnet Test Results
+
+on:
+  workflow_call:
+    inputs:
+      target_branch_to_compare:
+        description: "The target branch to compare against (e.g., main, refs/heads/main)."
+        required: true
+        type: string
+      dotnet-version:
+        description: "Dotnet SDK version to use for testing."
+        required: false
+        type: string
+        default: "8.0.x"
+      python-version:
+        description: "Python version to use for result processing scripts."
+        required: false
+        type: string
+        default: "3.10"
+      working-directory:
+        description: "Directory where dotnet commands should be executed."
+        required: false
+        type: string
+        default: "."
+      ping_latest_committer:
+        description: "If true, the latest committer on the PR will be added to the ping list."
+        required: false
+        type: boolean
+        default: false
+      runs_on:
+        required: false
+        type: string
+        default: "self-hosted"
+    secrets:
+      DISCORD_WEBHOOK_URL:
+        description: "Discord Webhook URL for failure notifications. If not provided, notifications are skipped."
+        required: false
+      DISCORD_USER_MAP:
+        description: 'JSON string mapping GitHub usernames to Discord User IDs (e.g., {"user1":"id1"}). If not provided, users won''t be pinged.'
+        required: false
+    outputs:
+      pr_total:
+        description: "Total tests in PR/source branch"
+        value: ${{ jobs.test-source-branch.outputs.total }}
+      pr_passed:
+        description: "Passed tests in PR/source branch"
+        value: ${{ jobs.test-source-branch.outputs.passed }}
+      pr_percentage:
+        description: "Pass percentage in PR/source branch"
+        value: ${{ jobs.test-source-branch.outputs.percentage }}
+      pr_collection_errors:
+        description: "PR branch has collection errors"
+        value: ${{ jobs.test-source-branch.outputs.collection_errors }}
+      pr_no_tests_found:
+        description: "PR branch has no tests found"
+        value: ${{ jobs.test-source-branch.outputs.no_tests_found }}
+      target_total:
+        description: "Total tests in target branch"
+        value: ${{ jobs.test-target-branch.outputs.total }}
+      target_passed:
+        description: "Passed tests in target branch"
+        value: ${{ jobs.test-target-branch.outputs.passed }}
+      target_percentage:
+        description: "Pass percentage in target branch"
+        value: ${{ jobs.test-target-branch.outputs.percentage }}
+      has_regressions:
+        description: "Boolean indicating if regressions were found"
+        value: ${{ jobs.compare-results.outputs.has_regressions }}
+      regression_count:
+        description: "Number of test regressions found"
+        value: ${{ jobs.compare-results.outputs.regression_count }}
+
+jobs:
+  test-source-branch:
+    runs-on: ${{ inputs.runs_on }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+    outputs:
+      total: ${{ steps.extract-results.outputs.total }}
+      passed: ${{ steps.extract-results.outputs.passed }}
+      percentage: ${{ steps.extract-results.outputs.percentage }}
+      collection_errors: ${{ steps.check-collection.outputs.has_collection_errors }}
+      no_tests_found: ${{ steps.check-collection.outputs.no_tests_found }}
+      has_errors: ${{ steps.check-collection.outputs.has_errors }}
+      error_type: ${{ steps.check-collection.outputs.error_type }}
+      error_details: ${{ steps.check-collection.outputs.error_details }}
+      failing_count: ${{ steps.extract-results.outputs.failing_count }}
+      skipped_count: ${{ steps.extract-results.outputs.skipped_count }}
+      xfailed_count: ${{ steps.extract-results.outputs.xfailed_count }}
+
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v4.2.2
+        with:
+          submodules: "recursive"
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "${{ inputs.dotnet-version }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: "${{ inputs.python-version }}"
+
+      - name: Restore dependencies
+        run: |
+          echo "Restoring dotnet dependencies..."
+          dotnet restore
+
+      - name: Check for test discovery issues
+        id: check-collection
+        run: |
+          echo "Running dotnet test --list-tests to verify discovery..."
+          set +e
+          dotnet test --list-tests > collection_output.txt 2>&1
+          LIST_EXIT_CODE=$?
+          set -e
+
+          # Set default values
+          HAS_COLLECTION_ERRORS="false"
+          NO_TESTS_FOUND="false"
+          ERROR_TYPE="none"
+          ERROR_DETAILS="none"
+
+          if [ "$LIST_EXIT_CODE" -ne 0 ]; then
+            echo "::error::Test discovery command failed in PR branch"
+            HAS_COLLECTION_ERRORS="true"
+            ERROR_TYPE="DiscoveryCommandFailed"
+            ERROR_DETAILS=$(head -n 200 collection_output.txt | tr '\n' ' ' | sed 's/"/\\"/g')
+          else
+            echo "dotnet test --list-tests executed successfully"
+
+            if grep -qi "Test Run Aborted" collection_output.txt || grep -qi "Test host process exited unexpectedly" collection_output.txt; then
+              echo "::error::Discovery encountered runtime errors"
+              HAS_COLLECTION_ERRORS="true"
+              ERROR_TYPE="RuntimeDiscoveryError"
+              ERROR_DETAILS=$(head -n 200 collection_output.txt | tr '\n' ' ' | sed 's/"/\\"/g')
+            else
+              TEST_COUNT=$(grep -Eo "Total tests: [0-9]+" collection_output.txt | tail -1 | awk '{print $3}')
+
+              if [[ -z "$TEST_COUNT" ]]; then
+                # Attempt to count listed tests as fallback
+                TEST_COUNT=$(grep -c "^    " collection_output.txt || echo "0")
+              fi
+
+              if grep -qi "No test is available" collection_output.txt || [[ -z "$TEST_COUNT" || "$TEST_COUNT" == "0" ]]; then
+                echo "::warning::No tests were found in the PR branch"
+                NO_TESTS_FOUND="true"
+                ERROR_TYPE="NoTestsFound"
+                ERROR_DETAILS="No tests were discovered by dotnet test --list-tests"
+              else
+                echo "Found $TEST_COUNT tests in PR branch"
+              fi
+            fi
+          fi
+
+          # Set all the outputs
+          echo "has_collection_errors=$HAS_COLLECTION_ERRORS" >> $GITHUB_OUTPUT
+          echo "no_tests_found=$NO_TESTS_FOUND" >> $GITHUB_OUTPUT
+          echo "error_type=$ERROR_TYPE" >> $GITHUB_OUTPUT
+          echo "error_details=$ERROR_DETAILS" >> $GITHUB_OUTPUT
+
+          # For backward compatibility
+          if [[ "$HAS_COLLECTION_ERRORS" == "true" || "$NO_TESTS_FOUND" == "true" ]]; then
+            echo "has_errors=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_errors=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Clean summary output
+          if [[ "$HAS_COLLECTION_ERRORS" == "true" ]]; then
+            echo "❌ Discovery Error: $ERROR_TYPE"
+          elif [[ "$NO_TESTS_FOUND" == "true" ]]; then
+            echo "⚠️ No Tests Found"
+          else
+            echo "✅ Discovery Success"
+          fi
+
+      - name: Run tests on PR Branch
+        if: steps.check-collection.outputs.has_collection_errors != 'true'
+        run: |
+          echo "Running dotnet tests on PR branch..."
+          mkdir -p TestResults
+          dotnet test --logger "trx;LogFileName=pr_results.trx" --results-directory TestResults --verbosity normal > test_output.txt 2>&1 || true
+
+          if [ -f TestResults/pr_results.trx ]; then
+            echo "✅ Test execution completed"
+          else
+            echo "❌ Test execution failed"
+          fi
+
+      - name: Convert TRX results to JSON
+        if: steps.check-collection.outputs.has_collection_errors != 'true'
+        run: |
+          python "$GITHUB_WORKSPACE/.github/scripts/trx_to_pytest_json.py" TestResults/pr_results.trx pr_results.json
+
+      - name: Extract test results and create artifacts
+        id: extract-results
+        run: |
+          echo "PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+
+          python -c "
+          import json
+          import sys
+          import os
+
+          # Default values in case file doesn't exist or is invalid
+          pr_total = 0
+          pr_passed = 0
+          pr_percentage = 0
+          failing_tests = []
+          skipped_tests = []
+          xfailed_tests = []
+          all_tests = []
+          passing_tests = []
+          skipped_tests_with_reasons = {}
+          xfailed_tests_with_reasons = {}
+
+          try:
+              print('Attempting to open pr_results.json')
+              with open('pr_results.json') as f:
+                  pr_results = json.load(f)
+                  print(f'JSON loaded successfully, keys: {list(pr_results.keys())}')
+              
+              # Check for collection errors by looking at exitcode or error patterns
+              if pr_results.get('exitcode', 0) > 1:
+                  print('Detected non-zero exitcode, likely a collection error')
+                  if 'collectors' in pr_results and pr_results['collectors']:
+                      print(f'Collection errors found: {pr_results["collectors"]}')
+                  pr_total = 0  # Explicitly set to 0 - no tests run when collection fails
+                  pr_passed = 0
+              elif 'summary' in pr_results and isinstance(pr_results['summary'], dict):
+                  # Normal case - extract data from summary
+                  summary = pr_results['summary']
+                  pr_total = summary.get('total', 0)
+                  pr_passed = summary.get('passed', 0)
+                  print(f'Results extracted from summary - Total: {pr_total}, Passed: {pr_passed}')
+                  
+                  # Extract all tests by outcome and collect all test nodeids with reasons
+                  if 'tests' in pr_results:
+                      print('Extracting failing, skipped, xfailed, and all tests with reasons')
+                      for test in pr_results['tests']:
+                          outcome = test.get('outcome')
+                          nodeid = test.get('nodeid', '')
+                          if nodeid:
+                              all_tests.append(nodeid)  # Track all tests regardless of outcome
+                              if outcome == 'passed':
+                                  passing_tests.append(nodeid)
+                              elif outcome in ['failed', 'error']:
+                                  failing_tests.append(nodeid)
+                              elif outcome == 'skipped':
+                                  skipped_tests.append(nodeid)
+                                  # Extract skip reason
+                                  skip_reason = 'No reason provided'
+                                  if 'longrepr' in test and test['longrepr']:
+                                      # longrepr can be a string or list, handle both
+                                      longrepr = test['longrepr']
+                                      if isinstance(longrepr, list) and longrepr:
+                                          skip_reason = str(longrepr[0]) if longrepr[0] else 'No reason provided'
+                                      elif isinstance(longrepr, str):
+                                          skip_reason = longrepr
+                                  elif 'call' in test and test['call'] and 'longrepr' in test['call']:
+                                      skip_reason = str(test['call']['longrepr'])
+                                  skipped_tests_with_reasons[nodeid] = skip_reason.strip()
+                              elif outcome == 'xfailed':
+                                  xfailed_tests.append(nodeid)
+                                  # Extract xfail reason
+                                  xfail_reason = 'No reason provided'
+                                  if 'longrepr' in test and test['longrepr']:
+                                      longrepr = test['longrepr']
+                                      if isinstance(longrepr, list) and longrepr:
+                                          xfail_reason = str(longrepr[0]) if longrepr[0] else 'No reason provided'
+                                      elif isinstance(longrepr, str):
+                                          xfail_reason = longrepr
+                                  elif 'call' in test and test['call'] and 'longrepr' in test['call']:
+                                      xfail_reason = str(test['call']['longrepr'])
+                                  xfailed_tests_with_reasons[nodeid] = xfail_reason.strip()
+                      
+                      print(f'Found {len(passing_tests)} passing tests')
+                      print(f'Found {len(failing_tests)} failing tests')
+                      print(f'Found {len(skipped_tests)} skipped tests')
+                      print(f'Found {len(xfailed_tests)} xfailed tests')
+                      print(f'Found {len(all_tests)} total discovered tests')
+              else:
+                  print('No valid summary structure found')
+              
+              # Calculate percentage safely
+              pr_percentage = (pr_passed / pr_total * 100) if pr_total > 0 else 0
+              print(f'Pass percentage calculated: {pr_percentage:.2f}%')
+              
+          except FileNotFoundError as e:
+              print(f'File not found error: {e}')
+          except KeyError as e:
+              print(f'Missing key in results file: {e}')
+              if 'pr_results' in locals():
+                  print(f'Available keys: {list(pr_results.keys())}')
+                  if 'summary' in pr_results:
+                      print(f'Summary structure: {pr_results["summary"]}')
+          except Exception as e:
+              print(f'Error processing results: {e}')
+              import traceback
+              print(f'Full exception: {traceback.format_exc()}')
+
+          print(f'Total tests: {pr_total}')
+          print(f'Passed tests: {pr_passed}')
+          print(f'Pass percentage: {pr_percentage:.2f}%')
+          print(f'Failing tests: {len(failing_tests)}')
+          print(f'Skipped tests: {len(skipped_tests)}')
+          print(f'Xfailed tests: {len(xfailed_tests)}')
+          print(f'All discovered tests: {len(all_tests)}')
+
+          # Set scalar outputs only (no large arrays)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'total={pr_total}\\n')
+              f.write(f'passed={pr_passed}\\n')
+              f.write(f'percentage={pr_percentage:.2f}\\n')
+              f.write(f'failing_count={len(failing_tests)}\\n')
+              f.write(f'skipped_count={len(skipped_tests)}\\n')
+              f.write(f'xfailed_count={len(xfailed_tests)}\\n')
+
+          # Extract warnings from test output
+          warnings_list = []
+          try:
+              with open('test_output.txt', 'r') as f:
+                  content = f.read()
+                  # Extract warnings section
+                  if '============================== warnings summary ===============================' in content:
+                      warnings_section = content.split('============================== warnings summary ===============================')[1]
+                      if '-- Docs:' in warnings_section:
+                          warnings_section = warnings_section.split('-- Docs:')[0]
+                      
+                      # Parse warnings - format is file path followed by indented warning details
+                      lines = warnings_section.split('\\n')
+                      current_warning_group = []
+                      
+                      for line in lines:
+                          line = line.rstrip()
+                          if not line or line.startswith('='):
+                              continue
+                          
+                          # Check if this is a file path (starts at column 0, ends with .py: or contains warning count)
+                          if not line.startswith(' ') and ('.py:' in line or 'warnings' in line):
+                              # Save previous warning group if exists
+                              if current_warning_group:
+                                  warnings_list.append('\\n'.join(current_warning_group))
+                              # Start new warning group
+                              current_warning_group = [line]
+                          elif line.startswith(' ') and current_warning_group:
+                              # This is part of the current warning (indented line)
+                              current_warning_group.append(line)
+                      
+                      # Don't forget the last warning group
+                      if current_warning_group:
+                          warnings_list.append('\\n'.join(current_warning_group))
+              
+              print(f'Extracted {len(warnings_list)} warning groups from test output')
+          except Exception as e:
+              print(f'Could not extract warnings: {e}')
+
+          # Save test lists to artifact files instead of job outputs
+          test_data = {
+              'passing_tests': passing_tests,
+              'failing_tests': failing_tests,
+              'skipped_tests': skipped_tests,
+              'xfailed_tests': xfailed_tests,
+              'all_tests': all_tests,
+              'skipped_tests_with_reasons': skipped_tests_with_reasons,
+              'xfailed_tests_with_reasons': xfailed_tests_with_reasons,
+              'warnings': warnings_list
+          }
+
+          with open('pr_test_data.json', 'w') as f:
+              json.dump(test_data, f, indent=2)
+
+          print('Test data saved to pr_test_data.json for artifact')
+          print('Results extraction completed')
+          "
+
+          echo "✅ Test results: ${{ steps.extract-results.outputs.passed }}/${{ steps.extract-results.outputs.total }} passed (${{ steps.extract-results.outputs.percentage }}%)"
+
+      - name: Upload PR branch artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_branch_data_${{ github.event.pull_request.number || github.run_id }}
+          path: |
+            pr_test_data.json
+            test_output.txt
+            pr_results.json
+          retention-days: 3
+          if-no-files-found: ignore
+
+  test-target-branch:
+    runs-on: ${{ inputs.runs_on }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+    outputs:
+      total: ${{ steps.check-collection.outputs.has_collection_errors == 'true' && steps.set-error-outputs.outputs.total || steps.extract-results.outputs.total }}
+      passed: ${{ steps.check-collection.outputs.has_collection_errors == 'true' && steps.set-error-outputs.outputs.passed || steps.extract-results.outputs.passed }}
+      percentage: ${{ steps.check-collection.outputs.has_collection_errors == 'true' && steps.set-error-outputs.outputs.percentage || steps.extract-results.outputs.percentage }}
+      collection_errors: ${{ steps.check-collection.outputs.has_collection_errors }}
+      no_tests_found: ${{ steps.check-collection.outputs.no_tests_found }}
+      has_errors: ${{ steps.check-collection.outputs.has_errors }}
+      error_type: ${{ steps.check-collection.outputs.error_type }}
+      error_details: ${{ steps.check-collection.outputs.error_details }}
+      passing_count: ${{ steps.check-collection.outputs.has_collection_errors == 'true' && steps.set-error-outputs.outputs.passing_count || steps.extract-results.outputs.passing_count }}
+
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4.2.2
+        with:
+          submodules: "recursive"
+          ref: ${{ inputs.target_branch_to_compare }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "${{ inputs.dotnet-version }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: "${{ inputs.python-version }}"
+
+      - name: Restore dependencies
+        run: |
+          echo "Restoring dotnet dependencies on target branch..."
+          dotnet restore
+
+      - name: Check for test discovery issues
+        id: check-collection
+        run: |
+          # Create verbose debug file for artifact
+          exec 3>&1 4>&2
+          exec 1> >(tee -a debug_target_collection.log) 2>&1
+
+          echo "Running dotnet test --list-tests on target branch..."
+          set +e
+          dotnet test --list-tests > collection_output.txt 2>&1
+          LIST_EXIT_CODE=$?
+          set -e
+
+          # Restore stdout/stderr for GitHub Actions
+          exec 1>&3 2>&4
+
+          # Set default values
+          HAS_COLLECTION_ERRORS="false"
+          NO_TESTS_FOUND="false"
+          ERROR_TYPE="none"
+          ERROR_DETAILS="none"
+
+          if [ "$LIST_EXIT_CODE" -ne 0 ]; then
+            echo "::warning::Test discovery command failed on target branch"
+            HAS_COLLECTION_ERRORS="true"
+            ERROR_TYPE="DiscoveryCommandFailed"
+            ERROR_DETAILS=$(head -n 200 collection_output.txt | tr '\n' ' ' | sed 's/"/\\"/g')
+          else
+            echo "dotnet test --list-tests executed successfully on target branch"
+
+            if grep -qi "Test Run Aborted" collection_output.txt || grep -qi "Test host process exited unexpectedly" collection_output.txt; then
+              echo "::warning::Discovery encountered runtime errors on target branch"
+              HAS_COLLECTION_ERRORS="true"
+              ERROR_TYPE="RuntimeDiscoveryError"
+              ERROR_DETAILS=$(head -n 200 collection_output.txt | tr '\n' ' ' | sed 's/"/\\"/g')
+            else
+              TEST_COUNT=$(grep -Eo "Total tests: [0-9]+" collection_output.txt | tail -1 | awk '{print $3}')
+
+              if [[ -z "$TEST_COUNT" ]]; then
+                TEST_COUNT=$(grep -c "^    " collection_output.txt || echo "0")
+              fi
+
+              if grep -qi "No test is available" collection_output.txt || [[ -z "$TEST_COUNT" || "$TEST_COUNT" == "0" ]]; then
+                echo "::warning::No tests were found in the target branch"
+                NO_TESTS_FOUND="true"
+                ERROR_TYPE="NoTestsFound"
+                ERROR_DETAILS="No tests were discovered by dotnet test --list-tests on the target branch"
+              else
+                echo "Found $TEST_COUNT tests in target branch"
+              fi
+            fi
+          fi
+
+          # Set all the outputs
+          echo "has_collection_errors=$HAS_COLLECTION_ERRORS" >> $GITHUB_OUTPUT
+          echo "no_tests_found=$NO_TESTS_FOUND" >> $GITHUB_OUTPUT
+          echo "error_type=$ERROR_TYPE" >> $GITHUB_OUTPUT
+          echo "error_details=$ERROR_DETAILS" >> $GITHUB_OUTPUT
+
+          # For backward compatibility
+          if [[ "$HAS_COLLECTION_ERRORS" == "true" || "$NO_TESTS_FOUND" == "true" ]]; then
+            echo "has_errors=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_errors=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Save full collection output to debug file for artifact
+          echo "=== FULL COLLECTION OUTPUT ===" >> debug_target_collection.log
+          cat collection_output.txt >> debug_target_collection.log
+
+      - name: Run tests on target branch
+        if: steps.check-collection.outputs.has_collection_errors != 'true'
+        run: |
+          echo "Running dotnet tests on target branch..."
+          mkdir -p TestResults
+          dotnet test --logger "trx;LogFileName=target_results.trx" --results-directory TestResults --verbosity normal > target_test_output.txt 2>&1 || true
+
+          if [ -f TestResults/target_results.trx ]; then
+            echo "✅ Test execution completed"
+          else
+            echo "❌ Test execution failed"
+          fi
+
+      - name: Convert target TRX results to JSON
+        if: steps.check-collection.outputs.has_collection_errors != 'true'
+        run: |
+          python "$GITHUB_WORKSPACE/.github/scripts/trx_to_pytest_json.py" TestResults/target_results.trx target_results.json
+
+      - name: Extract test results and create artifacts
+        id: extract-results
+        # Only run if there were no collection errors
+        if: steps.check-collection.outputs.has_collection_errors != 'true'
+        run: |
+          echo "Processing test results for target branch: ${{ inputs.target_branch_to_compare }}"
+
+          # Create debug file for detailed output
+          exec 3>&1 4>&2
+          exec 1> >(tee -a debug_target_extract_results.log) 2>&1
+
+          python -c "
+          import json
+          import sys
+          import os
+
+          print('Starting test results extraction script for target branch')
+
+          # Default values in case file doesn't exist or is invalid
+          target_total = 0
+          target_passed = 0
+          target_percentage = 0
+          passing_tests = []
+          failing_tests = []
+          skipped_tests = []
+          xfailed_tests = []
+          all_tests = []
+
+          try:
+              print('Attempting to open target_results.json')
+              with open('target_results.json') as f:
+                  target_results = json.load(f)
+                  print(f'JSON loaded successfully, keys: {list(target_results.keys())}')
+              
+              # Check for collection errors by looking at exitcode or error patterns
+              if target_results.get('exitcode', 0) > 1:
+                  print('Detected non-zero exitcode, likely a collection error')
+                  if 'collectors' in target_results and target_results['collectors']:
+                      print(f'Collection errors found: {target_results["collectors"]}')
+                  target_total = 0  # Explicitly set to 0 - no tests run when collection fails
+                  target_passed = 0
+              elif 'summary' in target_results and isinstance(target_results['summary'], dict):
+                  # Normal case - extract data from summary
+                  summary = target_results['summary']
+                  target_total = summary.get('total', 0)
+                  target_passed = summary.get('passed', 0)
+                  print(f'Results extracted from summary - Total: {target_total}, Passed: {target_passed}')
+                  
+                  # Extract all test outcomes
+                  if 'tests' in target_results:
+                      print('Extracting all test outcomes from target')
+                      for test in target_results['tests']:
+                          outcome = test.get('outcome')
+                          nodeid = test.get('nodeid', '')
+                          if nodeid:
+                              all_tests.append(nodeid)  # Track all tests regardless of outcome
+                              if outcome == 'passed':
+                                  passing_tests.append(nodeid)
+                              elif outcome in ['failed', 'error']:
+                                  failing_tests.append(nodeid)
+                              elif outcome == 'skipped':
+                                  skipped_tests.append(nodeid)
+                              elif outcome == 'xfailed':
+                                  xfailed_tests.append(nodeid)
+                      
+                      print(f'Found {len(passing_tests)} passing tests')
+                      print(f'Found {len(failing_tests)} failing tests')
+                      print(f'Found {len(skipped_tests)} skipped tests')
+                      print(f'Found {len(xfailed_tests)} xfailed tests')
+                      print(f'Found {len(all_tests)} total discovered tests')
+              else:
+                  print('No valid summary structure found')
+              
+              # Calculate percentage safely
+              target_percentage = (target_passed / target_total * 100) if target_total > 0 else 0
+              print(f'Pass percentage calculated: {target_percentage:.2f}%')
+              
+          except FileNotFoundError as e:
+              print(f'File not found error: {e}')
+          except KeyError as e:
+              print(f'Missing key in results file: {e}')
+              if 'target_results' in locals():
+                  print(f'Available keys: {list(target_results.keys())}')
+                  if 'summary' in target_results:
+                      print(f'Summary structure: {target_results["summary"]}')
+          except Exception as e:
+              print(f'Error processing results: {e}')
+              import traceback
+              print(f'Full exception: {traceback.format_exc()}')
+
+          print(f'Total tests: {target_total}')
+          print(f'Passed tests: {target_passed}')
+          print(f'Pass percentage: {target_percentage:.2f}%')
+          print(f'Passing tests: {len(passing_tests)}')
+          print(f'All discovered tests: {len(all_tests)}')
+
+          # Set scalar outputs only (no large arrays)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'total={target_total}\\n')
+              f.write(f'passed={target_passed}\\n')
+              f.write(f'percentage={target_percentage:.2f}\\n')
+              f.write(f'passing_count={len(passing_tests)}\\n')
+
+          # Extract warnings from test output
+          warnings_list = []
+          try:
+              with open('target_test_output.txt', 'r') as f:
+                  content = f.read()
+                  # Extract warnings section
+                  if '============================== warnings summary ===============================' in content:
+                      warnings_section = content.split('============================== warnings summary ===============================')[1]
+                      if '-- Docs:' in warnings_section:
+                          warnings_section = warnings_section.split('-- Docs:')[0]
+                      
+                      # Parse warnings - format is file path followed by indented warning details
+                      lines = warnings_section.split('\\n')
+                      current_warning_group = []
+                      
+                      for line in lines:
+                          line = line.rstrip()
+                          if not line or line.startswith('='):
+                              continue
+                          
+                          # Check if this is a file path (starts at column 0, ends with .py: or contains warning count)
+                          if not line.startswith(' ') and ('.py:' in line or 'warnings' in line):
+                              # Save previous warning group if exists
+                              if current_warning_group:
+                                  warnings_list.append('\\n'.join(current_warning_group))
+                              # Start new warning group
+                              current_warning_group = [line]
+                          elif line.startswith(' ') and current_warning_group:
+                              # This is part of the current warning (indented line)
+                              current_warning_group.append(line)
+                      
+                      # Don't forget the last warning group
+                      if current_warning_group:
+                          warnings_list.append('\\n'.join(current_warning_group))
+              
+              print(f'Extracted {len(warnings_list)} warning groups from target test output')
+          except Exception as e:
+              print(f'Could not extract warnings: {e}')
+
+          # Save test lists to artifact files instead of job outputs
+          test_data = {
+              'passing_tests': passing_tests,
+              'failing_tests': failing_tests,
+              'skipped_tests': skipped_tests,
+              'xfailed_tests': xfailed_tests,
+              'all_tests': all_tests,
+              'warnings': warnings_list
+          }
+
+          with open('target_test_data.json', 'w') as f:
+              json.dump(test_data, f, indent=2)
+
+          print('Test data saved to target_test_data.json for artifact')
+          print('Results extraction completed')
+          "
+
+          # Restore stdout/stderr for GitHub Actions
+          exec 1>&3 2>&4
+
+          echo "Target branch test results processed: ${{ steps.extract-results.outputs.passed }}/${{ steps.extract-results.outputs.total }} tests passed (${{ steps.extract-results.outputs.percentage }}%)"
+
+      - name: Upload target branch artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: target_branch_data_${{ github.event.pull_request.number || github.run_id }}
+          path: |
+            target_test_data.json
+            target_test_output.txt
+            target_results.json
+          retention-days: 3
+          if-no-files-found: ignore
+
+      # Add a step to set default outputs when collection errors are detected
+      - name: Set collection error outputs
+        id: set-error-outputs
+        if: steps.check-collection.outputs.has_collection_errors == 'true'
+        run: |
+          echo "::warning::Setting default outputs for target branch due to collection errors"
+          echo "total=0" >> $GITHUB_OUTPUT
+          echo "passed=0" >> $GITHUB_OUTPUT
+          echo "percentage=0.00" >> $GITHUB_OUTPUT
+          echo "passing_count=0" >> $GITHUB_OUTPUT
+
+  compare-results:
+    needs: [test-source-branch, test-target-branch]
+    runs-on: ${{ inputs.runs_on }}
+    outputs:
+      has_regressions: ${{ needs.perform-regression-analysis.outputs.has_regressions }}
+      regression_count: ${{ needs.perform-regression-analysis.outputs.regression_count }}
+
+    steps:
+      - name: Download test data artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "*_branch_data_${{ github.event.pull_request.number || github.run_id }}"
+          path: ./artifacts
+          merge-multiple: false
+
+      - name: Check for collection errors
+        run: |
+          PR_COLLECTION_ERRORS="${{ needs.test-source-branch.outputs.collection_errors }}"
+          PR_NO_TESTS="${{ needs.test-source-branch.outputs.no_tests_found }}"
+          PR_ERROR_TYPE="${{ needs.test-source-branch.outputs.error_type }}"
+          TARGET_COLLECTION_ERRORS="${{ needs.test-target-branch.outputs.collection_errors }}"
+
+          # Clean discovery status reporting
+          if [[ "$PR_COLLECTION_ERRORS" == "true" ]]; then
+            echo "❌ Discovery Error (PR): $PR_ERROR_TYPE"
+            exit 1
+          elif [[ "$PR_NO_TESTS" == "true" ]]; then
+            echo "❌ No Tests Found (PR)"
+            exit 1
+          else
+            echo "✅ Discovery Success (PR)"
+          fi
+
+          if [[ "$TARGET_COLLECTION_ERRORS" == "true" ]]; then
+            echo "⚠️ Discovery Error (Target)"
+          elif [[ "${{ needs.test-target-branch.outputs.no_tests_found }}" == "true" ]]; then
+            echo "⚠️ No Tests Found (Target)"
+          else
+            echo "✅ Discovery Success (Target)"
+          fi
+
+      - name: Run comprehensive regression analysis
+        run: |
+          echo "Running comprehensive regression analysis..."
+
+          python3 - << 'EOF'
+          import json
+          import os
+          import glob
+
+          try:
+              # Load test data from artifacts
+              target_data = {}
+              pr_data = {}
+              
+              # Load target and PR data
+              target_files = glob.glob('./artifacts/target_branch_data_*/target_test_data.json')
+              if target_files:
+                  with open(target_files[0], 'r') as f:
+                      target_data = json.load(f)
+              
+              pr_files = glob.glob('./artifacts/pr_branch_data_*/pr_test_data.json')
+              if pr_files:
+                  with open(pr_files[0], 'r') as f:
+                      pr_data = json.load(f)
+              
+              # Extract all test categories
+              target_passing = set(target_data.get('passing_tests', []))
+              target_failing = set(target_data.get('failing_tests', []))
+              target_skipped = set(target_data.get('skipped_tests', []))
+              target_xfailed = set(target_data.get('xfailed_tests', []))
+              target_warnings = set(target_data.get('warnings', []))
+              
+              pr_passing = set(pr_data.get('passing_tests', []))
+              pr_failing = set(pr_data.get('failing_tests', []))
+              pr_skipped = set(pr_data.get('skipped_tests', []))
+              pr_xfailed = set(pr_data.get('xfailed_tests', []))
+              pr_warnings = set(pr_data.get('warnings', []))
+              
+              # Debug: Print data for troubleshooting
+              print(f"🔍 Debug - Target branch data:")
+              print(f"  Passing: {len(target_passing)} tests")
+              print(f"  Failing: {len(target_failing)} tests")
+              print(f"  Skipped: {len(target_skipped)} tests")
+              print(f"  XFailed: {len(target_xfailed)} tests")
+              print(f"🔍 Debug - PR branch data:")
+              print(f"  Passing: {len(pr_passing)} tests")
+              print(f"  Failing: {len(pr_failing)} tests")
+              print(f"  Skipped: {len(pr_skipped)} tests")
+              print(f"  XFailed: {len(pr_xfailed)} tests")
+              
+              # All tests in each branch (regardless of outcome)
+              target_all_tests = target_passing.union(target_failing, target_skipped, target_xfailed)
+              pr_all_tests = pr_passing.union(pr_failing, pr_skipped, pr_xfailed)
+              
+              # Analyze different regression types
+              pass_to_fail = list(target_passing.intersection(pr_failing))
+              pass_to_skip = list(target_passing.intersection(pr_skipped.union(pr_xfailed)))
+              fail_to_skip = list(target_failing.intersection(pr_skipped))
+              pass_to_gone = list(target_passing - pr_all_tests)  # Passing tests that completely disappeared
+              fail_to_gone = list(target_failing - pr_all_tests)  # Failing tests that completely disappeared
+              discovery_regressions = list(pr_warnings - target_warnings)
+
+              # Create comprehensive regression report
+              has_any_regressions = bool(pass_to_fail or pass_to_skip or pass_to_gone or fail_to_gone or discovery_regressions)
+              has_improvements = bool(fail_to_skip)
+              
+              with open("comprehensive_regression_report.txt", "w") as f:
+                  f.write("COMPREHENSIVE REGRESSION ANALYSIS\n")
+                  f.write("=" * 50 + "\n\n")
+                  
+                  if pass_to_fail:
+                      f.write(f"PASS-TO-FAIL REGRESSIONS ({len(pass_to_fail)} tests)\n")
+                      f.write("Previously passing, now failing:\n")
+                      for i, test in enumerate(sorted(pass_to_fail), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+                  
+                  if pass_to_skip:
+                      f.write(f"PASS-TO-SKIP REGRESSIONS ({len(pass_to_skip)} tests)\n")
+                      f.write("Previously passing, now skipped or xfailed:\n")
+                      for i, test in enumerate(sorted(pass_to_skip), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+                  
+                  if fail_to_skip:
+                      f.write(f"FAIL-TO-SKIP IMPROVEMENTS ({len(fail_to_skip)} tests)\n")
+                      f.write("Previously failing, now skipped (treated as improvements):\n")
+                      for i, test in enumerate(sorted(fail_to_skip), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+                  
+                  if pass_to_gone:
+                      f.write(f"PASS-TO-GONE REGRESSIONS ({len(pass_to_gone)} tests)\n")
+                      f.write("Previously passing, now completely missing:\n")
+                      for i, test in enumerate(sorted(pass_to_gone), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+                  
+                  if fail_to_gone:
+                      f.write(f"FAIL-TO-GONE REGRESSIONS ({len(fail_to_gone)} tests)\n")
+                      f.write("Previously failing, now completely missing:\n")
+                      for i, test in enumerate(sorted(fail_to_gone), 1):
+                          f.write(f"  {i}. {test}\n")
+                      f.write("\n")
+                  
+                  if discovery_regressions:
+                      f.write(f"DISCOVERY REGRESSIONS ({len(discovery_regressions)} warnings)\n")
+                      f.write("New warnings not present in target branch:\n")
+                      for i, warning in enumerate(sorted(discovery_regressions), 1):
+                          f.write(f"  {i}. {warning[:200]}...\n")
+                      f.write("\n")
+                  
+                  if not has_any_regressions:
+                      if has_improvements:
+                          f.write("No regressions detected across all categories. Previously failing tests transitioned to skipped (treated as improvements).\n")
+                      else:
+                          f.write("No regressions detected across all categories.\n")
+              
+              # Also create the simple regression file for backward compatibility
+              if pass_to_fail:
+                  with open("regression_details.txt", "w") as f:
+                      f.write(f"Found {len(pass_to_fail)} tests that were passing in target branch but now failing in PR branch:\n\n")
+                      for idx, test in enumerate(sorted(pass_to_fail), 1):
+                          f.write(f"{idx}. {test}\n")
+              
+              # Print summary
+              print(f"📊 Regression Analysis Results:")
+              print(f"  Pass-to-Fail: {len(pass_to_fail)} tests")
+              print(f"  Pass-to-Skip: {len(pass_to_skip)} tests")
+              print(f"  Fail-to-Skip (improvements): {len(fail_to_skip)} tests")
+              print(f"  Pass-to-Gone: {len(pass_to_gone)} tests")
+              print(f"  Fail-to-Gone: {len(fail_to_gone)} tests")
+              print(f"  Discovery: {len(discovery_regressions)} warnings")
+              
+              if has_any_regressions:
+                  print(f"❌ Total regressions detected: {len(pass_to_fail) + len(pass_to_skip) + len(pass_to_gone) + len(fail_to_gone) + len(discovery_regressions)}")
+              else:
+                  if has_improvements:
+                      print(f"✅ No regressions detected. {len(fail_to_skip)} failing test(s) are now skipped (treated as improvements).")
+                  else:
+                      print("✅ No regressions detected")
+                  
+          except Exception as e:
+              print(f"Error in regression analysis: {e}")
+              import traceback
+              print(traceback.format_exc())
+          EOF
+
+          echo "✅ Comprehensive regression analysis completed"
+
+      - name: Check for regression details file
+        id: check-regressions
+        run: |
+          _has_regressions="false"
+          _regression_count="0"
+
+          if [ -f "regression_details.txt" ]; then
+            echo "Regression details file exists"
+            # Count regression lines (lines starting with a number and period)
+            _current_count=$(grep -c "^[0-9]\+\." regression_details.txt || echo "0")
+            echo "Found $_current_count regression items in file"
+
+            if [ "$_current_count" -gt 0 ]; then
+              _has_regressions="true"
+              _regression_count="$_current_count"
+              echo "::error::Test Regressions Found: $_regression_count test(s) that were passing in target branch are now **failing** in PR branch."
+              echo "Regression details:"
+              cat regression_details.txt
+            else
+              # File exists but no regressions counted (e.g. empty or malformed)
+              _has_regressions="false"
+              _regression_count="0"
+            fi
+          else
+            echo "No regression details file found - no regressions detected"
+            _has_regressions="false"
+            _regression_count="0"
+          fi
+
+          echo "HAS_REGRESSIONS=$_has_regressions" >> $GITHUB_OUTPUT
+          echo "REGRESSION_COUNT=$_regression_count" >> $GITHUB_OUTPUT
+
+          if [[ "$_has_regressions" == "false" ]]; then
+            if [ -f regression_details.txt ] && [ "$_has_regressions" == "false" ]; then
+               echo "::notice::Regression details file (regression_details.txt) was found but no valid regression entries were counted by this step, or the file was empty."
+            else
+               echo "No test regressions detected by this step."
+            fi
+          fi
+
+      - name: Upload regression details artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression_details_pr_${{ github.event.pull_request.number || github.run_id }}_tests
+          path: |
+            regression_details.txt
+            comprehensive_regression_report.txt
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Check for test additions and removals from artifacts
+        run: |
+          # Create analysis debug file
+          exec 3>&1 4>&2
+          exec 1> >(tee -a debug_test_changes_analysis.log) 2>&1
+
+          echo "Checking for test additions and removals between target and PR branches"
+
+          python3 - << 'EOF'
+          import json
+          import os
+          import glob
+
+          try:
+              # Load test data from artifacts
+              target_data = {}
+              pr_data = {}
+              
+              # Load target and PR data
+              target_files = glob.glob('./artifacts/target_branch_data_*/target_test_data.json')
+              if target_files:
+                  with open(target_files[0], 'r') as f:
+                      target_data = json.load(f)
+              
+              pr_files = glob.glob('./artifacts/pr_branch_data_*/pr_test_data.json')
+              if pr_files:
+                  with open(pr_files[0], 'r') as f:
+                      pr_data = json.load(f)
+              
+              # Extract test arrays
+              target_all = target_data.get('all_tests', [])
+              pr_all = pr_data.get('all_tests', [])
+              
+              print(f"Parsed {len(target_all)} total tests from target branch")
+              print(f"Parsed {len(pr_all)} total tests from PR branch")
+              
+              # Find test additions and removals using set operations
+              target_all_set = set(target_all)
+              pr_all_set = set(pr_all)
+              
+              removed_tests = list(target_all_set - pr_all_set)  # In target but not in PR
+              added_tests = list(pr_all_set - target_all_set)    # In PR but not in target
+              
+              # Report test changes
+              if removed_tests and added_tests:
+                  print(f"📊 Test Changes: +{len(added_tests)} added, -{len(removed_tests)} removed")
+              elif added_tests:
+                  print(f"✅ Test Additions: {len(added_tests)} new test(s) added")
+              elif removed_tests:
+                  print(f"⚠️ Test Removals: {len(removed_tests)} test(s) removed")
+              else:
+                  print("✅ Test suite unchanged")
+                  
+          except Exception as e:
+              print(f"Error in test addition/removal analysis: {e}")
+              import traceback
+              print(traceback.format_exc())
+          EOF
+
+          # Restore stdout/stderr for GitHub Actions
+          exec 1>&3 2>&4
+
+          echo "Test addition/removal analysis completed"
+
+      - name: Compare test results
+        run: |
+          echo "Target: ${{ needs.test-target-branch.outputs.passed }}/${{ needs.test-target-branch.outputs.total }} passed (${{ needs.test-target-branch.outputs.percentage }}%)"
+          echo "PR: ${{ needs.test-source-branch.outputs.passed }}/${{ needs.test-source-branch.outputs.total }} passed (${{ needs.test-source-branch.outputs.percentage }}%)"
+
+          if [[ "${{ needs.test-source-branch.outputs.total }}" == "0" ]]; then
+            echo "::error::No tests were found in the PR branch"
+            echo "❌ PR branch has no tests detected. Please ensure dotnet test can discover your test projects."
+            exit 1
+          fi
+
+          PR_PASSED=${{ needs.test-source-branch.outputs.passed }}
+          TARGET_PASSED=${{ needs.test-target-branch.outputs.passed }}
+          PR_PERCENTAGE=${{ needs.test-source-branch.outputs.percentage }}
+          TARGET_PERCENTAGE=${{ needs.test-target-branch.outputs.percentage }}
+          PR_TOTAL=${{ needs.test-source-branch.outputs.total }}
+          TARGET_TOTAL=${{ needs.test-target-branch.outputs.total }}
+
+          # Handle case where target has no tests
+          if [[ "$TARGET_TOTAL" == "0" ]]; then
+            if [[ "$PR_PASSED" -gt 0 ]]; then
+              echo "✅ PR branch has tests and some are passing (target branch has no tests)"
+              exit 0
+            else
+              echo "❌ PR branch has no passing tests"
+              echo "  - Pass percentage: $PR_PERCENTAGE%"
+              exit 1
+            fi
+          fi
+
+          # Check for regressions from meta-regression-analysis OR our comprehensive analysis
+          COMPREHENSIVE_REGRESSIONS="false"
+          if [ -f comprehensive_regression_report.txt ]; then
+            # Check if there are any actual regressions in our comprehensive report
+            if grep -q "REGRESSIONS.*([1-9]" comprehensive_regression_report.txt; then
+              COMPREHENSIVE_REGRESSIONS="true"
+            fi
+          fi
+
+          if [[ "${{ needs.perform-regression-analysis.outputs.has_regressions }}" == "true" ]] || [[ "$COMPREHENSIVE_REGRESSIONS" == "true" ]]; then
+            echo "❌ Test regressions detected from target branch"
+            REGRESSION_COUNT_VAL=${{ needs.perform-regression-analysis.outputs.regression_count }}
+
+            echo "### :x: Test Regressions Detected!" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Extract counts from comprehensive report if available
+            if [ -f comprehensive_regression_report.txt ]; then
+              PASS_FAIL_COUNT=$(grep -o "PASS-TO-FAIL REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              PASS_SKIP_COUNT=$(grep -o "PASS-TO-SKIP REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              FAIL_SKIP_IMPROVEMENTS_COUNT=$(grep -o "FAIL-TO-SKIP IMPROVEMENTS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              PASS_GONE_COUNT=$(grep -o "PASS-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              FAIL_GONE_COUNT=$(grep -o "FAIL-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              DISCOVERY_COUNT=$(grep -o "DISCOVERY REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+
+              TOTAL_REGRESSIONS=$((PASS_FAIL_COUNT + PASS_SKIP_COUNT + PASS_GONE_COUNT + FAIL_GONE_COUNT + DISCOVERY_COUNT))
+
+              echo "**$TOTAL_REGRESSIONS total regression(s) detected across multiple categories:**" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Category | Count |" >> $GITHUB_STEP_SUMMARY
+              echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+              echo "| Pass → Fail | $PASS_FAIL_COUNT |" >> $GITHUB_STEP_SUMMARY
+              echo "| Pass → Skip/XFail | $PASS_SKIP_COUNT |" >> $GITHUB_STEP_SUMMARY
+              echo "| Pass → Gone | $PASS_GONE_COUNT |" >> $GITHUB_STEP_SUMMARY
+              echo "| Fail → Gone | $FAIL_GONE_COUNT |" >> $GITHUB_STEP_SUMMARY
+              echo "| Discovery Warnings | $DISCOVERY_COUNT |" >> $GITHUB_STEP_SUMMARY
+              if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
+                echo "| Fail → Skip (Improvement) | $FAIL_SKIP_IMPROVEMENTS_COUNT |" >> $GITHUB_STEP_SUMMARY
+              fi
+              echo "" >> $GITHUB_STEP_SUMMARY
+              if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
+                echo "_Note: Fail → Skip transitions are treated as improvements and do not cause this job to fail._" >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+              fi
+            else
+              echo "**$REGRESSION_COUNT_VAL test regression(s) detected.** See detailed breakdown below:" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            # Display comprehensive regression report if available
+            if [ -f comprehensive_regression_report.txt ]; then
+                echo "📋 **Comprehensive Regression Analysis:**" >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+                
+                # Parse and format the comprehensive report for better GitHub display
+                while IFS= read -r line; do
+                    if [[ "$line" =~ ^[A-Z-].*(REGRESSIONS|IMPROVEMENTS).*(\([0-9]+) ]]; then
+                        echo "### $line" >> $GITHUB_STEP_SUMMARY
+                    elif [[ "$line" =~ ^Previously ]]; then
+                        echo "*$line*" >> $GITHUB_STEP_SUMMARY
+                        echo "" >> $GITHUB_STEP_SUMMARY
+                    elif [[ "$line" =~ ^[[:space:]]*[0-9]+\. ]]; then
+                        echo "- ${line#*. }" >> $GITHUB_STEP_SUMMARY
+                    elif [[ ! "$line" =~ ^=.*=$ ]] && [[ -n "$line" ]]; then
+                        echo "$line" >> $GITHUB_STEP_SUMMARY
+                    fi
+                done < comprehensive_regression_report.txt
+                
+                echo "" >> $GITHUB_STEP_SUMMARY
+            elif [ -f regression_details.txt ]; then
+                echo "### Pass-to-Fail Regressions" >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+                grep "^[0-9]\+\." regression_details.txt | while read -r line; do
+                    echo "- ${line#*. }" >> $GITHUB_STEP_SUMMARY
+                done
+                echo "" >> $GITHUB_STEP_SUMMARY
+            else
+                echo "::warning::Regression details files not found."
+            fi
+            
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This job (\`compare-results\`) has been marked as failed due to these regressions." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          # Highlight improvements in the summary even when no regressions were found
+          if [ -f comprehensive_regression_report.txt ]; then
+            FAIL_SKIP_IMPROVEMENTS_COUNT=$(grep -o "FAIL-TO-SKIP IMPROVEMENTS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+
+            if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
+              echo "### ✅ Test Improvements Detected" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Category | Count |" >> $GITHUB_STEP_SUMMARY
+              echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+              echo "| Fail → Skip (Improvement) | $FAIL_SKIP_IMPROVEMENTS_COUNT |" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "_Note: Fail → Skip transitions are treated as improvements and do not cause this job to fail._" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+
+          # Continue with the original comparison if no regressions
+          if (( $(echo "$PR_PASSED >= $TARGET_PASSED" | bc -l) )) && (( $(echo "$PR_PERCENTAGE >= $TARGET_PERCENTAGE" | bc -l) )); then
+            echo "✅ PR branch has equal or better test results than target branch"
+            
+            # Additional verbose information about improvement
+            if (( $(echo "$PR_PASSED > $TARGET_PASSED" | bc -l) )); then
+              IMPROVEMENT=$(( $PR_PASSED - $TARGET_PASSED ))
+              echo "  - Improvement: $IMPROVEMENT more passing tests than target branch"
+            fi
+            
+            if (( $(echo "$PR_PERCENTAGE > $TARGET_PERCENTAGE" | bc -l) )); then
+              PERCENTAGE_IMPROVEMENT=$(echo "$PR_PERCENTAGE - $TARGET_PERCENTAGE" | bc -l)
+              echo "  - Percentage improvement: +${PERCENTAGE_IMPROVEMENT}% compared to target branch"
+            fi
+            
+            exit 0
+          else
+            echo "❌ PR branch has worse test results than target branch"
+            echo "  - Passed tests: $PR_PASSED vs $TARGET_PASSED on target branch"
+            echo "  - Pass percentage: $PR_PERCENTAGE% vs $TARGET_PERCENTAGE% on target branch"
+            
+            # Add to job summary for general comparison failure
+            echo "### :x: Test Comparison Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The PR branch has worse test results than the target branch:" >> $GITHUB_STEP_SUMMARY
+            echo "- Passed tests: $PR_PASSED (PR) vs $TARGET_PASSED (Target)" >> $GITHUB_STEP_SUMMARY
+            echo "- Pass percentage: $PR_PERCENTAGE% (PR) vs $TARGET_PERCENTAGE% (Target)" >> $GITHUB_STEP_SUMMARY
+            
+            # Calculate regression metrics
+            if (( $(echo "$PR_PASSED < $TARGET_PASSED" | bc -l) )); then
+              REGRESSION=$(( $TARGET_PASSED - $PR_PASSED ))
+              echo "  - Regression: $REGRESSION fewer passing tests than target branch"
+            fi
+            
+            if (( $(echo "$PR_PERCENTAGE < $TARGET_PERCENTAGE" | bc -l) )); then
+              PERCENTAGE_REGRESSION=$(echo "$TARGET_PERCENTAGE - $PR_PERCENTAGE" | bc -l)
+              echo "  - Percentage regression: -${PERCENTAGE_REGRESSION}% compared to target branch"
+            fi
+            
+            exit 1
+          fi
+
+  perform-regression-analysis:
+    needs: [test-source-branch, test-target-branch]
+    uses: ./.github/workflows/meta-regression-analysis.yml
+    with:
+      item_type_singular: "test"
+      item_type_plural: "tests"
+      pr_number: ${{ github.event.pull_request.number }}
+      run_id: ${{ github.run_id }}
+      target_branch_artifact_name: target_branch_data_${{ github.event.pull_request.number || github.run_id }}
+      pr_branch_artifact_name: pr_branch_data_${{ github.event.pull_request.number || github.run_id }}
+
+  # Conditionally run notification job only if needed
+  prepare-notification:
+    name: Prepare Notification Data
+    needs:
+      [
+        test-source-branch,
+        test-target-branch,
+        compare-results,
+        perform-regression-analysis,
+      ]
+    # Notify on collection errors, no tests found, compare result failure, or if regressions are detected
+    if: |
+      always() &&
+      (
+        needs.test-source-branch.outputs.collection_errors == 'true' ||
+        needs.test-source-branch.outputs.no_tests_found == 'true' ||
+        needs.compare-results.result == 'failure' ||
+        needs.perform-regression-analysis.outputs.has_regressions == 'true'
+      )
+    runs-on: ${{ inputs.runs_on }}
+    outputs:
+      message_body: ${{ steps.construct_notification.outputs.message_body_out }}
+      ping_user_ids: ${{ steps.construct_notification.outputs.ping_user_ids_out }}
+      artifact_path: ${{ steps.construct_notification.outputs.artifact_path_out }}
+      should_notify: "true"
+      webhook_available_for_alert: ${{ steps.check_webhook_availability.outputs.webhook_available }}
+
+    steps:
+      - name: Check for Discord Webhook URL
+        id: check_webhook_availability
+        run: |
+          if [ -z "${{ secrets.DISCORD_WEBHOOK_URL }}" ]; then
+            echo "::notice::DISCORD_WEBHOOK_URL secret is not set. Discord notifications will likely be skipped by the alert workflow if it relies on this secret."
+            echo "webhook_available=false" >> $GITHUB_OUTPUT
+          else
+            echo "webhook_available=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Download regression details (if any)
+        id: download_regressions
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          name: regression_details_pr_${{ github.event.pull_request.number || github.run_id }}_tests
+          path: . # Download to current directory
+        continue-on-error: true
+
+      - name: Check downloaded regression file
+        if: always()
+        run: |
+          echo "Checking for regression details file..."
+          if [ -f "regression_details.txt" ]; then
+            echo "✅ Regression details file found"
+            echo "File size: $(wc -c < regression_details.txt) bytes"
+            echo "First few lines:"
+            head -5 regression_details.txt
+          else
+            echo "❌ Regression details file not found"
+          fi
+
+          if [ -f "comprehensive_regression_report.txt" ]; then
+            echo "✅ Comprehensive regression report found"
+            echo "File size: $(wc -c < comprehensive_regression_report.txt) bytes"
+          else
+            echo "❌ Comprehensive regression report not found"
+          fi
+
+      - name: Construct Discord Notification
+        id: construct_notification
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          SOURCE_TEST_RESULT: ${{ needs.test-source-branch.result }}
+          TARGET_TEST_RESULT: ${{ needs.test-target-branch.result }}
+          COMPARE_RESULT: ${{ needs.compare-results.result }}
+          PR_COLLECTION_ERRORS: ${{ needs.test-source-branch.outputs.collection_errors }}
+          PR_NO_TESTS_FOUND: ${{ needs.test-source-branch.outputs.no_tests_found }}
+          PR_ERROR_TYPE: ${{ needs.test-source-branch.outputs.error_type }}
+          PR_ERROR_DETAILS_TRUNCATED: ${{ needs.test-source-branch.outputs.error_details }}
+          HAS_REGRESSIONS: ${{ needs.perform-regression-analysis.outputs.has_regressions }}
+          REGRESSION_COUNT: ${{ needs.perform-regression-analysis.outputs.regression_count }}
+          PR_TOTAL_TESTS: ${{ needs.test-source-branch.outputs.total }}
+          PR_PASSED_TESTS: ${{ needs.test-source-branch.outputs.passed }}
+          PR_PERCENTAGE: ${{ needs.test-source-branch.outputs.percentage }}
+          TARGET_TOTAL_TESTS: ${{ needs.test-target-branch.outputs.total }}
+          TARGET_PASSED_TESTS: ${{ needs.test-target-branch.outputs.passed }}
+          TARGET_PERCENTAGE: ${{ needs.test-target-branch.outputs.percentage }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          TARGET_BRANCH_NAME: ${{ inputs.target_branch_to_compare }}
+          PR_BRANCH_NAME: ${{ github.head_ref }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_ASSIGNEES_JSON: ${{ toJson(github.event.pull_request.assignees) }}
+          USER_MAP_JSON: ${{ secrets.DISCORD_USER_MAP || '{}' }}
+          REGRESSION_FILE_PATH: "regression_details.txt"
+          DOWNLOAD_REGRESSIONS_OUTCOME: ${{ steps.download_regressions.outcome }}
+          INPUT_PING_LATEST_COMMITTER: ${{ inputs.ping_latest_committer }}
+        run: |
+          # Create debug file for detailed notification construction
+          exec 3>&1 4>&2
+          exec 1> >(tee -a debug_notification_construction.log) 2>&1
+
+          MESSAGE_LINES=() # Use an array to build message lines
+          PING_KEYS_OUTPUT="" # Will be comma-separated GitHub logins
+          ARTIFACT_PATH_OUTPUT=""
+
+          echo "Raw GH_ASSIGNEES_JSON value: [$GH_ASSIGNEES_JSON]"
+          echo "Raw USER_MAP_JSON value: [$USER_MAP_JSON]"
+
+          # 1. Determine Pings - Collect GitHub Logins to pass to alert-discord.yml
+          # Initialize PING_KEYS_OUTPUT
+          PING_KEYS_OUTPUT=""
+
+          # Add assignees to PING_KEYS_OUTPUT
+          if [ -n "$USER_MAP_JSON" ] && [ "$USER_MAP_JSON" != "{}" ] && command -v jq &> /dev/null; then
+            ASSIGNEE_LOGINS_ARRAY=($(echo "$GH_ASSIGNEES_JSON" | jq -r '.[].login // empty'))
+            echo "GH_ASSIGNEES_JSON received: $GH_ASSIGNEES_JSON"
+            echo "Extracted ASSIGNEE_LOGINS_ARRAY: (${ASSIGNEE_LOGINS_ARRAY[*]})"
+            echo "Count of assignees extracted: ${#ASSIGNEE_LOGINS_ARRAY[@]}"
+
+            MAPPED_ASSIGNEE_COUNT=0
+            TEMP_PING_KEYS=()
+
+            for assignee_login in "${ASSIGNEE_LOGINS_ARRAY[@]}"; do
+              if [ -z "$assignee_login" ]; then
+                echo "Skipping empty assignee login."
+                continue
+              fi
+              echo "Processing assignee for ping: '$assignee_login'"
+              # Check if this assignee_login exists as a key in USER_MAP_JSON
+              if echo "$USER_MAP_JSON" | jq -e --arg K "$assignee_login" '.[$K]' > /dev/null; then
+                echo "Assignee '$assignee_login' FOUND in USER_MAP_JSON."
+                TEMP_PING_KEYS+=("$assignee_login")
+                MAPPED_ASSIGNEE_COUNT=$((MAPPED_ASSIGNEE_COUNT + 1))
+              else
+                echo "Assignee '$assignee_login' NOT FOUND in USER_MAP_JSON."
+              fi
+            done
+
+            echo "Total assignees found in USER_MAP_JSON and added to pings: $MAPPED_ASSIGNEE_COUNT"
+
+            if [ ${#TEMP_PING_KEYS[@]} -gt 0 ]; then
+              PING_KEYS_OUTPUT=$(IFS=,; echo "${TEMP_PING_KEYS[*]}")
+              echo "Initial PING_KEYS_OUTPUT from assignees: [$PING_KEYS_OUTPUT]"
+            else
+              echo "No assignees found or GH_ASSIGNEES_JSON was empty, or no assignees were found in USER_MAP_JSON."
+            fi
+          elif [ -n "$USER_MAP_JSON" ] && [ "$USER_MAP_JSON" != "{}" ] && ! command -v jq &> /dev/null; then
+            echo "::warning::jq is not available. Cannot determine GitHub users (assignees) for pings."
+          else
+            echo "No user map JSON or jq not found. PING_KEYS_OUTPUT (from assignees) will be empty."
+          fi
+
+          # Add latest committer if INPUT_PING_LATEST_COMMITTER is true
+          if [[ "$INPUT_PING_LATEST_COMMITTER" == "true" ]]; then
+            echo "INPUT_PING_LATEST_COMMITTER is true. Attempting to fetch latest committer for PR #${PR_NUMBER}."
+            if command -v gh &> /dev/null && [ -n "$PR_NUMBER" ]; then
+              LATEST_COMMITTER_LOGIN_RAW=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[-1].author.login' 2>/dev/null || echo "")
+              
+              if [ -n "$LATEST_COMMITTER_LOGIN_RAW" ] && [ "$LATEST_COMMITTER_LOGIN_RAW" != "null" ]; then
+                # Apply bot filter (e.g., names ending in [bot] or -bot)
+                LATEST_COMMITTER_LOGIN=$(echo "$LATEST_COMMITTER_LOGIN_RAW" | grep -v -E -i '(\[bot\]$|-bot$)' || echo "")
+                
+                if [ -n "$LATEST_COMMITTER_LOGIN" ]; then
+                  echo "Latest committer identified: $LATEST_COMMITTER_LOGIN"
+                  
+                  # Check if this committer is already in PING_KEYS_OUTPUT
+                  ALREADY_IN_LIST=0
+                  if [ -n "$PING_KEYS_OUTPUT" ]; then # Only check if PING_KEYS_OUTPUT is not empty
+                    IFS=',' read -ra PING_ARRAY <<< "$PING_KEYS_OUTPUT"
+                    for key in "${PING_ARRAY[@]}"; do
+                      if [[ "$key" == "$LATEST_COMMITTER_LOGIN" ]]; then
+                        ALREADY_IN_LIST=1
+                        break
+                      fi
+                    done
+                  fi
+                  
+                  if [[ "$ALREADY_IN_LIST" -eq 0 ]]; then
+                    if [ -z "$PING_KEYS_OUTPUT" ]; then
+                      PING_KEYS_OUTPUT="$LATEST_COMMITTER_LOGIN"
+                    else
+                      PING_KEYS_OUTPUT="$PING_KEYS_OUTPUT,$LATEST_COMMITTER_LOGIN"
+                    fi
+                    echo "Added latest committer '$LATEST_COMMITTER_LOGIN' to PING_KEYS_OUTPUT. New list: [$PING_KEYS_OUTPUT]"
+                  else
+                    echo "Latest committer '$LATEST_COMMITTER_LOGIN' is already in PING_KEYS_OUTPUT (likely an assignee)."
+                  fi
+                else
+                  echo "Latest committer login '$LATEST_COMMITTER_LOGIN_RAW' was filtered out (likely a bot or pattern match) or empty after filter."
+                fi
+              else
+                echo "No latest committer login found for PR #$PR_NUMBER from gh command, or login was null."
+              fi
+            else
+              if ! command -v gh &> /dev/null; then
+                echo "::warning::gh command not available. Cannot fetch latest committer."
+              fi
+              if [ -z "$PR_NUMBER" ]; then
+                echo "::warning::PR_NUMBER is not set (event might not be a pull_request). Cannot fetch latest committer."
+              fi
+            fi
+          fi
+
+          # Restore stdout/stderr for GitHub Actions to show final summary
+          exec 1>&3 2>&4
+
+          # Make this a standard echo for better visibility of the final list
+          echo "Final Ping Keys Output (GitHub Logins from test-cs-dotnet.yml): [$PING_KEYS_OUTPUT]"
+          echo "ping_user_ids_out=$PING_KEYS_OUTPUT" >> $GITHUB_OUTPUT
+
+          # Store branch names in variables with proper quoting
+          PR_BRANCH="${PR_BRANCH_NAME:-unknown}"
+          TARGET_BRANCH="${TARGET_BRANCH_NAME:-unknown}"
+
+          # 2. Construct Message Body
+          MESSAGE_LINES+=("**Dotnet Test Comparison & Regression Analysis for PR [#${PR_NUMBER}: ${PR_TITLE}](${PR_URL})**")
+          MESSAGE_LINES+=("Branch: [\`${PR_BRANCH}\`](${REPO_URL}/tree/${PR_BRANCH}) against [\`${TARGET_BRANCH}\`](${REPO_URL}/tree/${TARGET_BRANCH})")
+          MESSAGE_LINES+=("---")
+
+          # Job Status Summary
+          MESSAGE_LINES+=("**Job Status:**")
+          LINT_STATUS="Success"
+          if [[ "$LINT_RESULT" == "failure" ]]; then LINT_STATUS="Failed"; elif [[ "$LINT_RESULT" == "skipped" ]]; then LINT_STATUS="Skipped"; fi
+          MESSAGE_LINES+=("- Linting: $LINT_STATUS")
+
+          SOURCE_TEST_STATUS="Success"
+          if [[ "$SOURCE_TEST_RESULT" == "failure" ]]; then SOURCE_TEST_STATUS="Failed"; elif [[ "$SOURCE_TEST_RESULT" == "skipped" ]]; then SOURCE_TEST_STATUS="Skipped"; fi
+          MESSAGE_LINES+=("- PR Branch Tests (\`${PR_BRANCH}\`): $SOURCE_TEST_STATUS")
+
+          TARGET_TEST_STATUS="Success"
+          if [[ "$TARGET_TEST_RESULT" == "failure" ]]; then TARGET_TEST_STATUS="Failed"; elif [[ "$TARGET_TEST_RESULT" == "skipped" ]]; then TARGET_TEST_STATUS="Skipped"; fi
+          MESSAGE_LINES+=("- Target Branch Tests (\`${TARGET_BRANCH}\`): $TARGET_TEST_STATUS")
+
+          COMPARE_STATUS="Success"
+          if [[ "$COMPARE_RESULT" == "failure" ]]; then COMPARE_STATUS="Failed"; elif [[ "$COMPARE_RESULT" == "skipped" ]]; then COMPARE_STATUS="Skipped"; fi
+          MESSAGE_LINES+=("- Comparison & Regression: $COMPARE_STATUS")
+          MESSAGE_LINES+=("---")
+
+          # Test Discovery Issues in PR Branch
+          if [[ "$PR_COLLECTION_ERRORS" == "true" ]]; then
+            MESSAGE_LINES+=("**:red_circle: ERROR: Test Discovery Failed in PR Branch (\`${PR_BRANCH}\`)**")
+            MESSAGE_LINES+=("  - Type: \`${PR_ERROR_TYPE}\`")
+            MESSAGE_LINES+=("  - This usually indicates import errors or syntax issues preventing tests from being collected.")
+            MESSAGE_LINES+=("  - See attached file for detailed error information.")
+          elif [[ "$PR_NO_TESTS_FOUND" == "true" ]]; then
+            MESSAGE_LINES+=("**:warning: WARNING: No Tests Found in PR Branch (\`${PR_BRANCH}\`)**")
+            MESSAGE_LINES+=("  - dotnet test did not discover any runnable tests.")
+            MESSAGE_LINES+=("  - Ensure your test files are correctly named (e.g., \`test_*.py\` or \`*_test.py\`) and located.")
+          fi
+
+          # Regression Analysis Summary
+          if [[ "$HAS_REGRESSIONS" == "true" ]]; then
+            MESSAGE_LINES+=("**:red_circle: REGRESSIONS DETECTED**")
+            
+            # Check if we have comprehensive regression file with categories
+            if [ -f "comprehensive_regression_report.txt" ]; then
+              # Extract counts from comprehensive report
+              PASS_FAIL_COUNT=$(grep -o "PASS-TO-FAIL REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              PASS_SKIP_COUNT=$(grep -o "PASS-TO-SKIP REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              FAIL_SKIP_IMPROVEMENTS_COUNT=$(grep -o "FAIL-TO-SKIP IMPROVEMENTS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              PASS_GONE_COUNT=$(grep -o "PASS-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              FAIL_GONE_COUNT=$(grep -o "FAIL-TO-GONE REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              DISCOVERY_COUNT=$(grep -o "DISCOVERY REGRESSIONS (\([0-9]*\)" comprehensive_regression_report.txt | grep -o "[0-9]*" || echo "0")
+              
+                             # Add category summaries (≤5 show paths, >5 show count + refer to file)
+               if [[ "$PASS_FAIL_COUNT" -gt 0 ]]; then
+                 if [[ "$PASS_FAIL_COUNT" -le 5 ]]; then
+                   MESSAGE_LINES+=("**Pass→Fail ($PASS_FAIL_COUNT):**")
+                   readarray -t test_paths < <(grep -A 100 "PASS-TO-FAIL REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$PASS_FAIL_COUNT | sed 's/^  [0-9]\+\. //')
+                   for test_path in "${test_paths[@]}"; do
+                     MESSAGE_LINES+=("• \`$test_path\`")
+                   done
+                 else
+                   MESSAGE_LINES+=("**Pass→Fail:** $PASS_FAIL_COUNT tests (see attached file)")
+                 fi
+               fi
+               
+               if [[ "$PASS_SKIP_COUNT" -gt 0 ]]; then
+                 if [[ "$PASS_SKIP_COUNT" -le 5 ]]; then
+                   MESSAGE_LINES+=("**Pass→Skip ($PASS_SKIP_COUNT):**")
+                   readarray -t test_paths < <(grep -A 100 "PASS-TO-SKIP REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$PASS_SKIP_COUNT | sed 's/^  [0-9]\+\. //')
+                   for test_path in "${test_paths[@]}"; do
+                     MESSAGE_LINES+=("• \`$test_path\`")
+                   done
+                 else
+                   MESSAGE_LINES+=("**Pass→Skip:** $PASS_SKIP_COUNT tests (see attached file)")
+                 fi
+               fi
+               
+               if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -gt 0 ]]; then
+                 if [[ "$FAIL_SKIP_IMPROVEMENTS_COUNT" -le 5 ]]; then
+                   MESSAGE_LINES+=(":white_check_mark: **Fail→Skip Improvements ($FAIL_SKIP_IMPROVEMENTS_COUNT):**")
+                   readarray -t test_paths < <(grep -A 100 "FAIL-TO-SKIP IMPROVEMENTS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$FAIL_SKIP_IMPROVEMENTS_COUNT | sed 's/^  [0-9]\+\. //')
+                   for test_path in "${test_paths[@]}"; do
+                     MESSAGE_LINES+=("• \`$test_path\`")
+                   done
+                 else
+                   MESSAGE_LINES+=(":white_check_mark: **Fail→Skip Improvements:** $FAIL_SKIP_IMPROVEMENTS_COUNT tests (see attached file)")
+                 fi
+               fi
+               
+               if [[ "$PASS_GONE_COUNT" -gt 0 ]]; then
+                 if [[ "$PASS_GONE_COUNT" -le 5 ]]; then
+                   MESSAGE_LINES+=("**Pass→Gone ($PASS_GONE_COUNT):**")
+                   readarray -t test_paths < <(grep -A 100 "PASS-TO-GONE REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$PASS_GONE_COUNT | sed 's/^  [0-9]\+\. //')
+                   for test_path in "${test_paths[@]}"; do
+                     MESSAGE_LINES+=("• \`$test_path\`")
+                   done
+                 else
+                   MESSAGE_LINES+=("**Pass→Gone:** $PASS_GONE_COUNT tests (see attached file)")
+                 fi
+               fi
+               
+               if [[ "$FAIL_GONE_COUNT" -gt 0 ]]; then
+                 if [[ "$FAIL_GONE_COUNT" -le 5 ]]; then
+                   MESSAGE_LINES+=("**Fail→Gone ($FAIL_GONE_COUNT):**")
+                   readarray -t test_paths < <(grep -A 100 "FAIL-TO-GONE REGRESSIONS" comprehensive_regression_report.txt | grep "^  [0-9]\+\." | head -$FAIL_GONE_COUNT | sed 's/^  [0-9]\+\. //')
+                   for test_path in "${test_paths[@]}"; do
+                     MESSAGE_LINES+=("• \`$test_path\`")
+                   done
+                 else
+                   MESSAGE_LINES+=("**Fail→Gone:** $FAIL_GONE_COUNT tests (see attached file)")
+                 fi
+               fi
+              
+              if [[ "$DISCOVERY_COUNT" -gt 0 ]]; then
+                if [[ "$DISCOVERY_COUNT" -le 5 ]]; then
+                  MESSAGE_LINES+=("**Discovery Warnings ($DISCOVERY_COUNT):**")
+                  MESSAGE_LINES+=("• $DISCOVERY_COUNT new warnings (see attached file)")
+                else
+                  MESSAGE_LINES+=("**Discovery Warnings:** $DISCOVERY_COUNT warnings (see attached file)")
+                fi
+              fi
+              
+            else
+              # Fallback to simple regression count
+              MESSAGE_LINES+=("  - **${REGRESSION_COUNT} test(s)** that were passing in \`${TARGET_BRANCH}\` are now **failing** in \`${PR_BRANCH}\`.")
+            fi
+          elif [[ "$COMPARE_RESULT" == "failure" ]] && [[ "$HAS_REGRESSIONS" != "true" ]]; then
+            # This case handles general comparison failures NOT due to specific regressions
+            MESSAGE_LINES+=("**:warning: TEST RESULTS DECLINED**")
+            MESSAGE_LINES+=("  - The PR branch shows a decrease in test success compared to the target branch, but no specific regressions were identified by the \`meta-regression-analysis\` job.")
+            MESSAGE_LINES+=("  - PR Branch (\`${PR_BRANCH}\`): **${PR_PASSED_TESTS}/${PR_TOTAL_TESTS} passed (${PR_PERCENTAGE}%)**")
+            MESSAGE_LINES+=("  - Target Branch (\`${TARGET_BRANCH}\`): **${TARGET_PASSED_TESTS}/${TARGET_TOTAL_TESTS} passed (${TARGET_PERCENTAGE}%)**")
+          elif [[ "$COMPARE_RESULT" == "success" ]] && [[ "$HAS_REGRESSIONS" != "true" ]]; then
+             MESSAGE_LINES+=("**:white_check_mark: NO REGRESSIONS DETECTED**")
+             MESSAGE_LINES+=("  - PR Branch (\`${PR_BRANCH}\`): **${PR_PASSED_TESTS}/${PR_TOTAL_TESTS} passed (${PR_PERCENTAGE}%)**")
+             MESSAGE_LINES+=("  - Target Branch (\`${TARGET_BRANCH}\`): **${TARGET_PASSED_TESTS}/${TARGET_TOTAL_TESTS} passed (${TARGET_PERCENTAGE}%)**")
+          fi
+
+          MESSAGE_LINES+=("---")
+          MESSAGE_LINES+=("[View Workflow Run](${ACTION_RUN_URL})")
+
+          # Set artifact path - always prefer comprehensive report if it exists
+          if [ -f "comprehensive_regression_report.txt" ]; then
+            ARTIFACT_PATH_OUTPUT="comprehensive_regression_report.txt"
+          elif [ -f "$REGRESSION_FILE_PATH" ] && [[ "$DOWNLOAD_REGRESSIONS_OUTCOME" == "success" ]]; then
+            ARTIFACT_PATH_OUTPUT="$REGRESSION_FILE_PATH"
+          else
+            ARTIFACT_PATH_OUTPUT=""
+          fi
+
+          # Construct with actual newlines
+          FINAL_MESSAGE_BODY=$(printf "%s\\n" "${MESSAGE_LINES[@]}")
+          if [ ${#MESSAGE_LINES[@]} -gt 0 ]; then
+            # Remove the very last actual newline
+            FINAL_MESSAGE_BODY="${FINAL_MESSAGE_BODY%\\n}"
+          fi
+
+          echo "Final message body prepared in test-cs-dotnet.yml"
+
+          echo "message_body_out<<EOF" >> $GITHUB_OUTPUT
+          echo "$FINAL_MESSAGE_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "artifact_path_out=$ARTIFACT_PATH_OUTPUT" >> $GITHUB_OUTPUT
+
+  notify-discord:
+    name: Send Discord Notification
+    needs: [prepare-notification]
+    if: |
+      always() &&
+      needs.prepare-notification.outputs.should_notify == 'true' &&
+      needs.prepare-notification.outputs.webhook_available_for_alert == 'true'
+    uses: ./.github/workflows/alert-discord.yml
+    with:
+      message_body: ${{ needs.prepare-notification.outputs.message_body }}
+      ping_user_ids: ${{ needs.prepare-notification.outputs.ping_user_ids }}
+      artifact_paths: ${{ needs.prepare-notification.outputs.artifact_path }}
+      should_notify: ${{ needs.prepare-notification.outputs.should_notify }}
+      runs_on: ${{ inputs.runs_on }}
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_USER_MAP: ${{ secrets.DISCORD_USER_MAP }}


### PR DESCRIPTION
## Summary
- add a reusable workflow that runs dotnet tests and publishes results compatible with the regression analysis jobs
- add a helper script to convert TRX results into the pytest-style JSON structure consumed by the comparison logic

## Testing
- python3 -m compileall .github/scripts/trx_to_pytest_json.py

------
https://chatgpt.com/codex/tasks/task_e_68f3c5837a00832e98a1b74bc7b1e415